### PR TITLE
feat(goal): durable, evaluator-graded goal loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ crews goal pause | resume      # pause / re-prime from durable state and continu
 crews goal clear               # write a retrospective; keep history
 ```
 
+### Running a crew as a goal loop
+
+`Crew.kickoff()` ([`src/crew/crew.ts`](src/crew/crew.ts)) is the durable loop controller. It schedules tasks into waves and drives each wave as one checkpoint/evaluator cycle: it runs the wave's tasks (the worker), surfaces machine-checkable evidence (`tasks_completed` / `tasks_total` / `tasks_failed` + exit code) to a **separate** evaluator (`crewCompletionEvaluator` by default — a distinct id from the worker), writes a durable, idempotent checkpoint under `audits/goals/<id>/`, and stops when every task is completed. Task execution is injected via `runTask`, so the same controller drives tests, dry runs, and real (bridge-backed) execution.
+
+```ts
+import { Crew } from './src/crew';
+
+const out = await crew.kickoff({
+  // Execute one task; production supplies a bridge-backed runner.
+  runTask: async (task) => ({ taskId: task.id, status: 'completed', durationMs: 0 }),
+});
+// out.tasks / out.waves / out.totalTime — durable log under audits/goals/crew-<name>/
+```
+
+Re-running the same crew appends **no duplicate** checkpoints (content-keyed), durable files are git-staged on every checkpoint, and timestamps come from the JS runtime (cross-platform). This feature was **dogfooded**: the goal contract and per-checkpoint evaluator log used to build it live in [`audits/goals/goal-loop-feature/`](audits/goals/goal-loop-feature/).
+
 ---
 
 <details>

--- a/README.md
+++ b/README.md
@@ -182,6 +182,62 @@ The framework handles planning, spawning, coordination, and retry. Your agents d
 
 ---
 
+## Goal loop
+
+For long-running, coherent work with a clear success condition, wrap a crew run in a **goal loop**. A goal is a durable, evaluator-graded contract: once set, the crew works in checkpoints toward a **transcript-verifiable stopping condition** without per-turn steering, and stops when that condition is provably met.
+
+**A goal is a 7-field contract** (`src/goal/contract.ts`):
+
+| Field | Answers |
+|---|---|
+| `objective` | What is the crew trying to achieve? |
+| `stoppingCondition` | Exactly when to stop — a runnable command, measurable threshold, or observable artifact. |
+| `validationLoop` | The command that proves progress at every checkpoint. |
+| `inputsToReadFirst` | Files/docs to read before acting. |
+| `constraints` | Hard rules that must hold throughout. |
+| `forbiddenMoves` | Specific actions the crew must not take. |
+| `checkpointCadence` | What proves a checkpoint complete. |
+
+`executionContext` (cwd, shell, timeout, services, side-effect boundaries) is optional but recommended.
+
+**How the loop runs.** On each turn the [`GoalRunner`](src/goal/runner.ts) (a) runs the worker, (b) invokes a **separate evaluator** — the worker never grades itself — that grades progress from *surfaced evidence only* and records `reason` / `command` / `result`, (c) writes a checkpoint per cadence, and (d) stops when the stopping condition is met. It **auto-pauses after two consecutive validation failures** on the same slice so it never compounds bad work.
+
+**Two-tier memory.** Working state (in-memory plan + turn/token counters + latest checkpoint) lives in the runner; **durable** state is persisted to `audits/goals/<id>/` (the 7-field contract in `contract.json` + `goal.md`, an append-only `checkpoints.jsonl`, and a `retrospective.md` on clear) so it is git-trackable and survives a lost session.
+
+The evaluator is a pluggable interface — supply any grader from a2a-crews' model/provider layer via `functionEvaluator`, or use the conservative `DefaultEvaluator`.
+
+```ts
+import { GoalRunner, DefaultEvaluator, crewWorker } from './src/goal';
+
+const runner = new GoalRunner();
+runner.start({
+  objective: 'Migrate internal/api from Gin to chi',
+  stoppingCondition: '`bun test` exits 0 and coverage >= 80%',
+  validationLoop: 'bun test --coverage',
+  inputsToReadFirst: ['src/api/router.ts'],
+  constraints: ['No route shape changes'],
+  forbiddenMoves: ['Do not open a PR'],
+  checkpointCadence: 'every file migrated + tests green',
+});
+
+// Wrap a crew run as the worker; a SEPARATE evaluator grades each turn.
+const worker = crewWorker(crew, ({ turn }) => runNextSlice(turn));
+await runner.run(worker, new DefaultEvaluator());
+```
+
+**CLI** (lifecycle equivalent to the slash commands):
+
+```bash
+crews goal start goal.json     # activate a 7-field contract (replaces any prior goal)
+crews goal status              # condition, turns, tokens, checkpoints, latest evaluator reason
+crews goal show                # print the full contract
+crews goal checkpoint "note"   # force-write a checkpoint now
+crews goal pause | resume      # pause / re-prime from durable state and continue
+crews goal clear               # write a retrospective; keep history
+```
+
+---
+
 <details>
 <summary><strong>Under the Hood — Real A2A Protocol</strong></summary>
 

--- a/audits/goals/goal-loop-feature/checkpoints.md
+++ b/audits/goals/goal-loop-feature/checkpoints.md
@@ -1,0 +1,137 @@
+# Checkpoint log — goal-loop-feature
+
+Append-only. One entry per meaningful unit of work. Each checkpoint records the
+**worker** step (what changed) and is followed by a **separate evaluator** pass
+(a distinct grading step, id `goal-loop-evaluator`) that judges progress against
+the stopping condition and records the exact command run + its result. Entries
+are never rewritten or reordered; re-running the loop appends nothing when a
+slice is unchanged (idempotent).
+
+Stopping condition (recap): branch `feat/goal-loop` pushed **and** PR open
+**and** `bun test` (0 failures) + `bun x tsc --noEmit` (exit 0) green with output
+pasted below.
+
+---
+
+## Checkpoint 1 — Contract adopted; inputs read; baseline established
+**When:** 2026-07-09T13:05-07:00 · **Turn:** 1 · **Cadence:** unit complete
+
+**Worker**
+- Adopted the 7-field goal contract (`contract.md`) before writing integration code.
+- Read the inputs-to-read-first: `src/crew/crew.ts` (stub `kickoff` throwing
+  `Not implemented`), `src/crew/checkpoint.ts`, `src/crew/process.ts`
+  (`computeWaves`), `src/cli/index.ts` dispatch (`case 'goal'` → `handleGoal`),
+  the shipped `src/goal/*` module, and `.github/workflows/ci.yml`.
+- Confirmed no existing test pins `kickoff()`'s `Not implemented` behavior, so it
+  is safe to implement.
+
+**Files:** `audits/goals/goal-loop-feature/contract.md` (new),
+`audits/goals/goal-loop-feature/checkpoints.md` (new)
+
+**Evaluator pass** (id `goal-loop-evaluator`, separate from worker)
+- Command: `bun x tsc --noEmit` → `tsc_exit=0`
+- Command: `bun test` → `222 pass, 0 fail, 759 expect() calls, 17 files`
+- Judgment: contract is complete and its stopping condition is
+  transcript-verifiable; baseline is green, so subsequent slices have a clean
+  starting point. Stopping condition **not yet met** (deeper integration + a new
+  push still required).
+- Progress: ~0.15 · conditionMet: **false**
+
+---
+
+## Checkpoint 2 — checkpoint.ts extended into goal checkpoints
+**When:** 2026-07-09T13:22-07:00 · **Turn:** 2 · **Cadence:** unit complete
+
+**Worker**
+- Added `toGoalCheckpointDraft(cp, bridge)` + `GoalCheckpointBridge` to
+  `src/crew/checkpoint.ts`: maps a crew `Checkpoint` into a durable
+  `GoalCheckpointDraft`, content-keyed via `checkpointKey` (idempotent). The
+  evaluator's grade (`evaluatorId`/`progress`/`evidence`/`validation`) travels
+  *alongside* the worker's verified/remaining work, never merged into it.
+- Re-exported the checkpoint helpers from `src/crew/index.ts`.
+
+**Files:** `src/crew/checkpoint.ts`, `src/crew/index.ts`
+
+**Evaluator pass** (id `goal-loop-evaluator`, separate from worker)
+- Command: `bun x tsc --noEmit` → `tsc_exit=0`
+- Command: `bun test tests/crew-goal-loop.test.ts` → bridge specs
+  `toGoalCheckpointDraft` **2/2 pass** (mapping + stable/idempotent key).
+- Judgment: bridge is correct and idempotency-keyed; checkpoint.ts now feeds the
+  durable goal log. Stopping condition not yet met.
+- Progress: ~0.4 · conditionMet: **false**
+
+---
+
+## Checkpoint 3 — Crew.kickoff() implemented as the durable loop controller
+**When:** 2026-07-09T13:41-07:00 · **Turn:** 3 · **Cadence:** unit complete
+
+**Worker**
+- Replaced the `throw new Error('Not implemented')` stub in `src/crew/crew.ts`
+  with a durable loop: `computeWaves()` (process.ts) is adapted into
+  checkpoint/evaluator cycles. Each wave = one turn: (a) run the wave's tasks
+  (worker, injectable `runTask`), (b) surface machine-checkable evidence
+  (`tasks_completed`/`tasks_total`/`tasks_failed` + exit code) to a **separate**
+  evaluator, (c) build a crew `Checkpoint` and bridge it into the durable,
+  idempotent, staged goal log under `audits/goals/<id>/`, (d) stop when the
+  evaluator reports all tasks completed. Adds `crewCompletionEvaluator`
+  (distinct id from the worker), `crewGoalId` (stable id ⇒ idempotent re-runs),
+  `nextAttempt`-based attempt counter (defaults to 0), and a completion
+  retrospective. One active goal per session.
+
+**Files:** `src/crew/crew.ts`, `src/crew/index.ts`,
+`tests/crew-goal-loop.test.ts` (new)
+
+**Evaluator pass** (id `goal-loop-evaluator`, separate from worker)
+- Command: `bun x tsc --noEmit` → `tsc_exit=0`
+- Command: `bun test tests/crew-goal-loop.test.ts` → **9 pass, 0 fail,
+  38 expect() calls**. Covers: completion + durable two-tier state, wave order,
+  evaluator-id-collision rejection, grade-time impersonation guard, no-false-
+  completion on failure, idempotent re-run (no duplicate checkpoints), staging
+  on every checkpoint.
+- Judgment: kickoff is the durable loop controller; worker and evaluator are
+  distinct; durable files written, staged, and idempotent. Core targets met.
+- Progress: ~0.8 · conditionMet: **false** (push + PR update still pending)
+
+---
+
+## Checkpoint 4 — /goal CLI dispatch confirmed
+**When:** 2026-07-09T13:47-07:00 · **Turn:** 4 · **Cadence:** unit complete
+
+**Worker**
+- Confirmed the `/goal`-style command is wired in `src/cli/index.ts` dispatch
+  (target #4): `case 'goal'` (line 152) → `handleGoal()` (line 952) with
+  subcommands `status | show | list | start/set | checkpoint | pause | resume |
+  clear` (+ aliases `stop/off/reset/none/cancel`). No code change required.
+
+**Files:** (none — verification only)
+
+**Evaluator pass** (id `goal-loop-evaluator`, separate from worker)
+- Command: `Select-String src/cli/index.ts -Pattern "case 'goal'|handleGoal|..."`
+  → matched `case 'goal':` (152), `handleGoal` (952), and all lifecycle
+  subcommands.
+- Judgment: dispatch target satisfied by the shipped module.
+- Progress: ~0.85 · conditionMet: **false**
+
+---
+
+## Checkpoint 5 — Full validation green
+**When:** 2026-07-09T13:52-07:00 · **Turn:** 5 · **Cadence:** validation gate
+
+**Worker**
+- Ran the full validation loop on the whole tree after the integration.
+
+**Files:** (none — validation only)
+
+**Evaluator pass** (id `goal-loop-evaluator`, separate from worker)
+- Command: `bun x tsc --noEmit` → `tsc_exit=0`
+- Command: `bun test` → **231 pass, 0 fail, 797 expect() calls, 18 files**
+  (was 222 pre-integration; +9 new integration tests).
+- Command: `git status --porcelain audits/` → only
+  `audits/goals/goal-loop-feature/**` present (tests use isolated temp dirs — no
+  repo pollution).
+- Judgment: build + tests green; two validation gates of the stopping condition
+  satisfied. Remaining: push branch + update PR (Checkpoint 6).
+- Progress: ~0.9 · conditionMet: **false**
+
+---
+

--- a/audits/goals/goal-loop-feature/checkpoints.md
+++ b/audits/goals/goal-loop-feature/checkpoints.md
@@ -135,3 +135,32 @@ pasted below.
 
 ---
 
+## Checkpoint 6 — Shipped: branch pushed, PR updated
+**When:** 2026-07-09T13:58-07:00 · **Turn:** 6 · **Cadence:** stopping condition
+
+**Worker**
+- Committed the integration + dogfooding artifacts as `9a2e0de`
+  (`feat(crew): drive Crew.kickoff() as a durable goal loop`) with the required
+  trailers, authored as the personal account's noreply identity.
+- Pushed `feat/goal-loop` → `origin` (`d8edc4d..9a2e0de`) as the personal
+  account. PR #28 (`aviraldua93/a2a-crews`) auto-updates with these commits.
+
+**Files:** (ship — no source changes beyond commit `9a2e0de`)
+
+**Evaluator pass** (id `goal-loop-evaluator`, separate from worker)
+- Command: `bun x tsc --noEmit` → `tsc_exit=0`
+- Command: `bun test` → **231 pass, 0 fail, 797 expect() calls, 18 files**
+- Command: `gh auth status --active` → `Active account: true` for the personal
+  account (push authorized; no fallback account used).
+- Command: `git push origin feat/goal-loop` → `d8edc4d..9a2e0de` (accepted).
+- Judgment: branch pushed **and** PR open (`.../pull/28`) **and** `bun test`
+  (0 failures) + `bun x tsc --noEmit` (exit 0) green with output pasted above.
+  All clauses of the stopping condition are satisfied and transcript-verifiable.
+- Progress: 1.0 · conditionMet: **true**
+
+**Outcome:** goal `goal-loop-feature` **completed**. Worker and evaluator stayed
+distinct steps throughout; every checkpoint was durable, staged, and idempotent.
+
+---
+
+

--- a/audits/goals/goal-loop-feature/contract.md
+++ b/audits/goals/goal-loop-feature/contract.md
@@ -1,9 +1,10 @@
 # Goal: Implement a durable goal-loop feature in a2a-crews
 
-**State:** active
+**State:** completed
 **Id:** goal-loop-feature
 **Branch:** feat/goal-loop
 **Started:** 2026-07-09T13:03:12-07:00
+**Achieved:** 2026-07-09T13:58-07:00 — branch pushed (`9a2e0de`), PR #28 updated, `bun test` 231 pass / `bun x tsc --noEmit` exit 0
 **Autopilot:** yes
 
 > Dogfooding note: this contract was adopted **before** writing the deeper

--- a/audits/goals/goal-loop-feature/contract.md
+++ b/audits/goals/goal-loop-feature/contract.md
@@ -1,0 +1,72 @@
+# Goal: Implement a durable goal-loop feature in a2a-crews
+
+**State:** active
+**Id:** goal-loop-feature
+**Branch:** feat/goal-loop
+**Started:** 2026-07-09T13:03:12-07:00
+**Autopilot:** yes
+
+> Dogfooding note: this contract was adopted **before** writing the deeper
+> integration code. The loop below (see `checkpoints.md`) was then run for real —
+> each unit of work is a checkpoint followed by a **separate** evaluator pass that
+> records the exact command run and its result. The worker (implementation) and
+> the evaluator (grading) are distinct steps, never merged.
+
+## Contract
+
+- **Objective:** Implement a durable goal-loop feature in a2a-crews — a 7-field
+  `GoalContract` type, a `GoalRunner` that drives a worker to a verifiable
+  stopping condition, a **separate** evaluator (the worker never self-grades),
+  and two-tier memory (in-memory working state vs durable `audits/goals/<id>/`) —
+  then flesh out `Crew.kickoff()` as the durable loop controller and open a PR on
+  `aviraldua93/a2a-crews`.
+
+- **Stopping condition:** Branch `feat/goal-loop` is pushed **and** the PR is open
+  (`https://github.com/aviraldua93/a2a-crews/pull/28`) **and** both `bun test`
+  (exit 0, 0 failures) and `bun x tsc --noEmit` (exit 0) pass locally with their
+  passing output pasted into `checkpoints.md`. State-verifiable from the git
+  transcript and the pasted command exit codes/output.
+
+- **Validation loop:** After each checkpoint, run `bun x tsc --noEmit`, then
+  `bun test`; fix every failure before continuing. Record the command and its
+  result as evidence in the evaluator pass.
+
+- **Inputs to read first:**
+  - the recursive repo tree, `README.md`, `package.json`
+  - `src/crew/crew.ts` (stub `kickoff` — the durable loop controller to flesh out)
+  - `src/crew/checkpoint.ts` (crew checkpoint shape to extend into goal checkpoints)
+  - `src/crew/process.ts` (`computeWaves` scheduler to adapt into checkpoint/evaluator cycles)
+  - `src/cli/index.ts` (command dispatch, ~lines 132-153; `handleGoal` ~952)
+  - `src/spawner/prompt.ts`, `.github/workflows/ci.yml`
+  - the shipped goal module: `src/goal/{contract,evaluator,store,runner,index}.ts`
+
+- **Constraints:**
+  - Bun runtime; use the repo's existing test framework (`bun test`, `bun:test`).
+  - Idiomatic TypeScript (ESM, strict); follow existing repo conventions/lint.
+  - Own only `src/**`, tests, `package.json`/build config (only if genuinely
+    needed), and root `README.md`, plus these `audits/goals/goal-loop-feature/**`
+    dogfooding artifacts.
+  - Keep changes surgical; do not regress the existing 222 tests.
+  - Cross-platform (Windows + Unix): timestamps from the JS runtime; never shell
+    out to `date -u`; staging via argv, no Unix-only shell assumptions.
+
+- **Forbidden moves:**
+  - Do not touch `.github/skills/goal/**` (owned by a second agent).
+  - Clean-room port of the design only: no source-specific project or person
+    names/identifiers anywhere in code, tests, docs, or history — use generic
+    names (`goal`, `goal-loop`, `GoalContract`, `GoalRunner`).
+  - Do not fall back to the alternate/work account for push; push only as the
+    personal account that owns the target repo.
+  - The worker must not grade itself — grading is a separate evaluator step.
+
+- **Checkpoint cadence:** Write a checkpoint after each meaningful unit
+  (contract adopted, checkpoint bridge, kickoff loop, CLI confirmation, full
+  validation, README, ship). Each checkpoint is followed by a separate evaluator
+  pass that records the exact command + result; a checkpoint is complete only
+  when `bun x tsc --noEmit` and `bun test` are green for that slice.
+
+- **Execution context:**
+  - cwd: `C:\Users\aviraldua\a2a-crews-work`
+  - shell: `pwsh` (Windows PowerShell)
+  - side-effect boundaries: writes limited to owned paths; durable goal state
+    under `audits/goals/<id>/`; git operations on branch `feat/goal-loop` only.

--- a/src/cli/display.ts
+++ b/src/cli/display.ts
@@ -1,3 +1,5 @@
+import type { GoalStatus } from '../goal';
+
 export function printHeader(title: string): void {
   console.log(`\n  ╔${'═'.repeat(46)}╗`);
   console.log(`  ║  ${title.padEnd(43)}║`);
@@ -34,5 +36,25 @@ export function printSummary(totalTime: number, waves: number, tasksCompleted: n
   console.log(`  Tasks: ${tasksCompleted}/${totalTasks}`);
   console.log(`  Retries: ${retries}`);
   console.log(`  Failed tasks: ${failedTasks}`);
+  console.log();
+}
+
+export function printGoalStatus(s: GoalStatus): void {
+  const icon =
+    s.state === 'completed' ? '✅' :
+    s.state === 'active' ? '🎯' :
+    s.state === 'paused' ? '⏸️' :
+    s.state === 'cleared' ? '🧹' : '·';
+  printHeader('GOAL STATUS');
+  console.log(`  ${icon} ${s.state.toUpperCase()}${s.goalId ? `  (${s.goalId})` : ''}`);
+  if (s.objective) console.log(`  Objective: ${s.objective}`);
+  const cond = s.activeCondition ?? s.achievedCondition;
+  if (cond) console.log(`  Condition: ${cond}`);
+  const mins = Math.floor(s.runtimeMs / 60000);
+  const secs = Math.round((s.runtimeMs % 60000) / 1000);
+  console.log(`  Turns: ${s.turns}   Checkpoints: ${s.checkpoints}   Tokens: ${s.tokenSpend}`);
+  console.log(`  Attempts: ${s.attempts}   Consecutive failures: ${s.consecutiveFailures}   Runtime: ${mins}m ${secs}s`);
+  if (s.branch) console.log(`  Branch: ${s.branch}`);
+  if (s.lastReason) console.log(`  Latest: ${s.lastReason}`);
   console.log();
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,7 +13,8 @@ import { spawnAgent } from '../spawner/terminal';
 import { generateAgentPrompt } from '../spawner/prompt';
 import { createWorktree, mergeWorktree, removeWorktree, cleanupAllWorktrees, pruneWorktrees } from '../spawner/worktree';
 import { listPresets, loadPreset } from '../templates';
-import { printHeader, printRoles, printTasks, printSummary } from './display';
+import { printHeader, printRoles, printTasks, printSummary, printGoalStatus } from './display';
+import { GoalRunner, GoalStore, validateContract, type GoalContract } from '../goal';
 
 // ── Central bridge registry (#19) ──────────────────────────────────
 const REGISTRY_DIR = join(homedir(), '.a2a-crews', 'active-bridges');
@@ -147,6 +148,9 @@ switch (command) {
     break;
   case 'templates':
     handleTemplates();
+    break;
+  case 'goal':
+    await handleGoal(args);
     break;
   default:
     printHelp();
@@ -943,6 +947,154 @@ function handleTemplates(): void {
   console.log('  Use: crews plan "<scenario>" to auto-select a template.\n');
 }
 
+// ── Goal loop ─────────────────────────────────────────────────────────
+
+async function handleGoal(argv: string[]): Promise<void> {
+  const sub = (argv[0] ?? 'status').toLowerCase();
+  const store = new GoalStore({ baseDir: projectDir });
+  const runner = new GoalRunner({ store, emitEvents: false });
+
+  // Load the current goal: active first, else the most recent paused one.
+  const loadCurrent = (): boolean => {
+    if (runner.loadActive()) return true;
+    const paused = store.listRecords().filter(r => r.state === 'paused');
+    if (paused.length > 0) {
+      runner.load(paused[paused.length - 1].id);
+      return true;
+    }
+    return false;
+  };
+
+  switch (sub) {
+    case 'status': {
+      if (!loadCurrent()) {
+        printHeader('GOAL');
+        console.log('  No active goal. Start one with:');
+        console.log('    crews goal start <contract.json>\n');
+        return;
+      }
+      printGoalStatus(runner.status());
+      return;
+    }
+
+    case 'show': {
+      if (!loadCurrent()) {
+        console.log('  No goal to show.');
+        return;
+      }
+      const shown = runner.show();
+      if (shown) console.log(`\n${shown.markdown}`);
+      return;
+    }
+
+    case 'list': {
+      const records = store.listRecords();
+      printHeader('GOALS');
+      if (records.length === 0) {
+        console.log('  (none)\n');
+        return;
+      }
+      for (const r of records) {
+        console.log(`  [${r.state.padEnd(9)}] ${r.id}`);
+        console.log(`       ${r.contract.objective}`);
+      }
+      console.log();
+      return;
+    }
+
+    case 'start':
+    case 'set': {
+      const file = argv[1];
+      if (!file) {
+        console.log('  Usage: crews goal start <contract.json>');
+        return;
+      }
+      const path = resolve(projectDir, file);
+      if (!existsSync(path)) {
+        console.log(`  Contract file not found: ${path}`);
+        return;
+      }
+      let parsed: Partial<GoalContract>;
+      try {
+        parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<GoalContract>;
+      } catch (e) {
+        console.log(`  Invalid JSON: ${(e as Error).message}`);
+        return;
+      }
+      const validation = validateContract(parsed);
+      if (!validation.valid) {
+        printHeader('GOAL — INVALID CONTRACT');
+        if (validation.missing.length) console.log(`  Missing fields: ${validation.missing.join(', ')}`);
+        for (const err of validation.errors) console.log(`  ✗ ${err}`);
+        console.log();
+        return;
+      }
+      const record = runner.start(parsed);
+      printHeader('GOAL ACTIVATED');
+      console.log(`  ${record.contract.objective}`);
+      console.log(`  Stopping condition: ${record.contract.stoppingCondition}`);
+      console.log(`  Durable state: audits/goals/${record.id}/\n`);
+      return;
+    }
+
+    case 'checkpoint': {
+      if (!loadCurrent()) {
+        console.log('  No goal to checkpoint.');
+        return;
+      }
+      const title = argv.slice(1).join(' ') || undefined;
+      const cp = runner.checkpoint({ title });
+      console.log(`  ✅ Checkpoint #${cp.checkpointNumber} → audits/goals/${cp.goalId}/checkpoints.jsonl`);
+      return;
+    }
+
+    case 'pause': {
+      if (!loadCurrent()) {
+        console.log('  No active goal to pause.');
+        return;
+      }
+      try {
+        printGoalStatus(runner.pause());
+      } catch (e) {
+        console.log(`  ${(e as Error).message}`);
+      }
+      return;
+    }
+
+    case 'resume': {
+      if (!loadCurrent()) {
+        console.log('  No goal to resume.');
+        return;
+      }
+      try {
+        printGoalStatus(runner.resume());
+      } catch (e) {
+        console.log(`  ${(e as Error).message}`);
+      }
+      return;
+    }
+
+    case 'clear':
+    case 'stop':
+    case 'off':
+    case 'reset':
+    case 'none':
+    case 'cancel': {
+      if (!loadCurrent()) {
+        console.log('  No goal to clear.');
+        return;
+      }
+      runner.clear(sub);
+      console.log(`  Goal cleared (${sub}). Retrospective written; history kept.\n`);
+      return;
+    }
+
+    default:
+      console.log(`  Unknown goal subcommand: ${sub}`);
+      console.log('  Try: status | show | list | start <file> | checkpoint | pause | resume | clear');
+  }
+}
+
 // ── Help ──────────────────────────────────────────────────────────────
 
 function printHelp(): void {
@@ -958,6 +1110,16 @@ function printHelp(): void {
     watch [name]        Stream live status from agents
     stop [name]         Cancel all tasks and stop agents
     templates           List all available crew templates
+    goal <subcommand>   Drive a durable, evaluator-graded goal loop
+
+  Goal subcommands:
+    goal status            Show the active goal (default)
+    goal show              Print the full goal contract
+    goal list              List every goal in audits/goals/
+    goal start <file>      Activate a goal from a 7-field contract JSON
+    goal checkpoint [note] Force-write a checkpoint now
+    goal pause | resume    Pause / re-prime and continue the loop
+    goal clear             Clear the goal and write a retrospective
 
   Options:
     --project-dir, -d   Target project directory (default: cwd)

--- a/src/crew/checkpoint.ts
+++ b/src/crew/checkpoint.ts
@@ -1,3 +1,6 @@
+import { checkpointKey, type GoalCheckpointDraft } from '../goal/store';
+import type { Evidence } from '../goal/evaluator';
+
 export interface Checkpoint {
   role: string;
   checkpointNumber: number;
@@ -28,4 +31,78 @@ export function createCheckpoint(data: Partial<Checkpoint> & { role: string; cur
 
 export function checkpointToString(cp: Checkpoint): string {
   return JSON.stringify(cp, null, 2);
+}
+
+/**
+ * Grading metadata attached by a *separate* evaluator when a crew checkpoint is
+ * promoted into the durable goal-checkpoint log. Kept distinct from the crew
+ * checkpoint itself so the worker (which builds the {@link Checkpoint}) never
+ * supplies its own grade.
+ */
+export interface GoalCheckpointBridge {
+  goalId: string;
+  turn: number;
+  /** Identity of the evaluator that graded this slice (proves worker separation). */
+  evaluatorId: string;
+  /** 0..1 progress toward the stopping condition, per the evaluator. */
+  progress: number;
+  /** Whether validation passed for this slice. */
+  passed: boolean;
+  /** Verification attempt count (defaults to 0 upstream; first attempt is 1). */
+  attempt: number;
+  /** Auditable evidence (reason/command/result) from the evaluator. */
+  evidence: Evidence;
+  command?: string;
+  result?: string;
+  timestamp?: string;
+  blocked?: string | null;
+}
+
+/**
+ * Bridge a crew {@link Checkpoint} into a durable {@link GoalCheckpointDraft}.
+ *
+ * This is how the crew's native checkpoint shape becomes an append-only entry in
+ * `audits/goals/<id>/checkpoints.jsonl`. The draft is content-keyed via
+ * {@link checkpointKey} so re-appending the same slice is a no-op (idempotent),
+ * and the evaluator's grade travels alongside the worker's verified/remaining
+ * work rather than being merged into it.
+ */
+export function toGoalCheckpointDraft(cp: Checkpoint, bridge: GoalCheckpointBridge): GoalCheckpointDraft {
+  const verified = cp.completedWork.length
+    ? cp.completedWork.join('; ')
+    : cp.taskStatus === 'complete'
+      ? cp.currentTask
+      : `${cp.currentTask} (in progress)`;
+  const remains = cp.remainingWork.length
+    ? cp.remainingWork.join('; ')
+    : cp.taskStatus === 'complete'
+      ? 'none'
+      : 'in progress';
+  const title = `${cp.currentTask} — checkpoint ${cp.checkpointNumber}`.slice(0, 140);
+  return {
+    goalId: bridge.goalId,
+    turn: bridge.turn,
+    timestamp: bridge.timestamp ?? cp.timestamp,
+    title,
+    verified,
+    remains,
+    blocked: bridge.blocked ?? null,
+    validation: {
+      command: bridge.command,
+      result: bridge.result,
+      passed: bridge.passed,
+      attempt: bridge.attempt,
+    },
+    evidence: bridge.evidence,
+    evaluatorId: bridge.evaluatorId,
+    progress: bridge.progress,
+    key: checkpointKey({
+      goalId: bridge.goalId,
+      turn: bridge.turn,
+      title,
+      verified,
+      validationResult: bridge.result,
+      reason: bridge.evidence.reason,
+    }),
+  };
 }

--- a/src/crew/crew.ts
+++ b/src/crew/crew.ts
@@ -1,5 +1,22 @@
 import type { Agent } from './agent';
 import type { Task } from './task';
+import { computeWaves } from './process';
+import { createCheckpoint, toGoalCheckpointDraft } from './checkpoint';
+import { eventBus, type EventType } from './events';
+import {
+  assertSeparateEvaluator,
+  EvaluatorSeparationError,
+  functionEvaluator,
+  GoalStore,
+  nextAttempt,
+  normalizeContract,
+  type Evaluation,
+  type Evaluator,
+  type Evidence,
+  type GoalContract,
+  type GoalRecord,
+  type WorkerResult,
+} from '../goal';
 
 export type ProcessType = 'sequential' | 'wave';
 
@@ -26,9 +43,181 @@ export class Crew {
     this.tasks = config.tasks;
   }
 
-  async kickoff(): Promise<CrewOutput> {
-    // TODO: implement orchestration
-    throw new Error('Not implemented');
+  /**
+   * Run the crew as a durable goal loop.
+   *
+   * Wave scheduling ({@link computeWaves}) is adapted into checkpoint/evaluator
+   * cycles: each wave is one turn in which the crew (a) runs the wave's tasks
+   * (the *worker*), (b) surfaces evidence to a **separate** {@link Evaluator}
+   * that grades progress (the worker never grades itself), (c) writes a durable,
+   * idempotent checkpoint under `audits/goals/<id>/`, and (d) stops when the
+   * evaluator reports the stopping condition met (all tasks completed, none
+   * failed). Durable state is git-staged on every checkpoint and survives a lost
+   * session; re-running the same crew appends no duplicate checkpoints.
+   *
+   * `runTask` is the injection seam: the default marks tasks completed in-process
+   * (useful for tests and dry runs), while production wiring supplies a
+   * bridge-backed executor. There is one active goal per session.
+   */
+  async kickoff(options: KickoffOptions = {}): Promise<CrewOutput> {
+    const now = options.now ?? (() => new Date().toISOString());
+    const emit = (type: EventType, data: Record<string, unknown>): void => {
+      if (options.emitEvents !== false) eventBus.emit(type, data);
+    };
+    const store = options.store ?? new GoalStore({ baseDir: options.baseDir, now });
+    const runTask = options.runTask ?? defaultTaskRunner;
+    const workerId = `crew:${this.name}`;
+    const evaluator = options.evaluator ?? crewCompletionEvaluator();
+    assertSeparateEvaluator({ id: workerId }, evaluator);
+
+    const waves = computeWaves(this.tasks);
+    const totalTasks = this.tasks.length;
+
+    const contract = normalizeContract(options.contract ?? this.deriveContract(waves.length));
+    const id = crewGoalId(this.name);
+    const existing = store.readRecord(id);
+    const record: GoalRecord = {
+      id,
+      contract,
+      state: 'active',
+      autopilot: true,
+      createdAt: existing?.createdAt ?? now(),
+      updatedAt: now(),
+      achievedCondition: null,
+    };
+    store.writeRecord(record);
+    emit('crew:started', { name: this.name, waves: waves.length, tasks: totalTasks });
+    emit('goal:started', { goalId: id, objective: contract.objective });
+
+    const startedAt = Date.now();
+    const results: TaskRunResult[] = [];
+    const completedIds = new Set<string>();
+    const evaluations: Evaluation[] = [];
+    let attempts = 0;
+    let met = false;
+
+    for (let w = 0; w < waves.length; w++) {
+      const wave = waves[w];
+      emit('wave:started', { wave: w + 1, of: waves.length, tasks: wave.map(t => t.id) });
+
+      // ── Worker: run the wave's tasks ───────────────────────────────
+      const waveResults: TaskRunResult[] = [];
+      for (const task of wave) {
+        task.status = 'in_progress';
+        emit('task:started', { taskId: task.id });
+        const outcome = await runTask(task, { crew: this, wave: w + 1 });
+        task.status = outcome.status;
+        results.push(outcome);
+        waveResults.push(outcome);
+        if (outcome.status === 'completed') {
+          completedIds.add(task.id);
+          emit('task:completed', { taskId: task.id });
+        } else {
+          emit('task:failed', { taskId: task.id, status: outcome.status });
+        }
+      }
+      attempts = nextAttempt(attempts);
+
+      const waveFailed = waveResults.some(r => r.status !== 'completed');
+      const failedCount = results.filter(r => r.status !== 'completed').length;
+      const allDone = completedIds.size === totalTasks;
+      const ts = now();
+      const summary =
+        `wave ${w + 1}/${waves.length}: ` +
+        `${waveResults.filter(r => r.status === 'completed').length}/${wave.length} tasks ok`;
+
+      // Evidence the *separate* evaluator will grade — machine-checkable counts.
+      const surfaced: WorkerResult = {
+        workerId,
+        turn: w + 1,
+        summary,
+        command: contract.validationLoop,
+        result: `tasks_completed=${completedIds.size} tasks_total=${totalTasks} tasks_failed=${failedCount}`,
+        exitCode: waveFailed ? 1 : 0,
+      };
+
+      // Crew checkpoint (checkpoint.ts): the worker's view of verified/remaining.
+      const checkpoint = createCheckpoint({
+        role: this.name,
+        checkpointNumber: w + 1,
+        currentTask: `wave ${w + 1}/${waves.length}`,
+        taskStatus: allDone ? 'complete' : 'partial',
+        completedWork: waveResults.filter(r => r.status === 'completed').map(r => r.taskId),
+        remainingWork: this.tasks.filter(t => !completedIds.has(t.id)).map(t => t.id),
+        notes: summary,
+      });
+      checkpoint.timestamp = ts;
+
+      // ── Evaluator: a distinct grading step, reading only surfaced evidence ──
+      const evaluation = await evaluator.evaluate(contract, surfaced, evaluations);
+      if (evaluation.evaluatorId === workerId) throw new EvaluatorSeparationError(workerId);
+      evaluations.push(evaluation);
+
+      // Bridge the crew checkpoint into the durable, idempotent goal log.
+      const draft = toGoalCheckpointDraft(checkpoint, {
+        goalId: id,
+        turn: w + 1,
+        evaluatorId: evaluation.evaluatorId,
+        progress: evaluation.progress,
+        passed: !waveFailed,
+        attempt: attempts,
+        evidence: evaluation.evidence,
+        command: surfaced.command,
+        result: surfaced.result,
+        timestamp: ts,
+        blocked: waveFailed ? `wave ${w + 1} had ${failedCount} failed task(s) so far` : null,
+      });
+      const { checkpoint: written } = store.appendCheckpoint(draft);
+      record.updatedAt = written.timestamp;
+      store.writeRecord(record);
+      emit('goal:checkpoint', { goalId: id, checkpointNumber: written.checkpointNumber });
+      emit('wave:completed', { wave: w + 1, progress: evaluation.progress });
+
+      if (evaluation.conditionMet) {
+        met = true;
+        break;
+      }
+    }
+
+    const allCompleted = completedIds.size === totalTasks;
+    record.state = allCompleted ? 'completed' : 'active';
+    record.achievedCondition = allCompleted ? contract.stoppingCondition : null;
+    record.updatedAt = now();
+    store.writeRecord(record);
+    if (allCompleted) {
+      store.writeRetrospective(id, buildCrewRetrospective(record, store, now));
+      store.stage(id);
+      emit('goal:completed', { goalId: id, condition: contract.stoppingCondition });
+      emit('crew:completed', { name: this.name });
+    } else {
+      emit('crew:failed', { name: this.name, completed: completedIds.size, total: totalTasks });
+    }
+
+    return {
+      tasks: results.map(r => ({
+        taskId: r.taskId,
+        status: r.status,
+        output: r.output,
+        duration: r.durationMs,
+      })),
+      totalTime: Date.now() - startedAt,
+      waves: met ? evaluations.length : waves.length,
+    };
+  }
+
+  /** Derive a verifiable 7-field contract from the crew's shape. */
+  private deriveContract(waveCount: number): Partial<GoalContract> {
+    return {
+      objective: `Complete crew "${this.name}": ${this.scenario}`,
+      stoppingCondition:
+        `All ${this.tasks.length} crew task(s) reach status \`completed\` with 0 \`failed\` ` +
+        `(state-verifiable from each Task.status)`,
+      validationLoop: `crews watch ${this.name}`,
+      inputsToReadFirst: [`${this.tasks.length} task(s) scheduled across ${waveCount} wave(s)`],
+      constraints: [`process: ${this.process}`, 'one active goal per session'],
+      forbiddenMoves: ['do not mark a task completed unless its acceptance criteria are met'],
+      checkpointCadence: 'one durable checkpoint per wave',
+    };
   }
 }
 
@@ -43,4 +232,101 @@ export interface TaskOutput {
   status: 'completed' | 'failed' | 'canceled';
   output?: string;
   duration: number;
+}
+
+/** Result of running a single task within a wave. */
+export interface TaskRunResult {
+  taskId: string;
+  status: 'completed' | 'failed' | 'canceled';
+  output?: string;
+  durationMs: number;
+}
+
+/** Executes a single task. The injection seam for real (bridge-backed) execution. */
+export type TaskRunner = (
+  task: Task,
+  ctx: { crew: Crew; wave: number; agent?: Agent },
+) => TaskRunResult | Promise<TaskRunResult>;
+
+export interface KickoffOptions {
+  /** How to execute a single task. Defaults to an in-process runner that completes it. */
+  runTask?: TaskRunner;
+  /** Separate grader. Defaults to a crew-completion evaluator distinct from the worker. */
+  evaluator?: Evaluator;
+  /** Root under which durable goal state (`audits/goals/<id>/`) is written. Defaults to cwd. */
+  baseDir?: string;
+  /** Injected store (tests); takes precedence over {@link KickoffOptions.baseDir}. */
+  store?: GoalStore;
+  /** Timestamp source. Defaults to the runtime ISO clock (never a shell). */
+  now?: () => string;
+  /** Emit lifecycle events on the crew event bus. Default true. */
+  emitEvents?: boolean;
+  /** Override the contract derived from the crew's shape. */
+  contract?: Partial<GoalContract>;
+}
+
+/** Stable, idempotent durable id for a crew's goal loop (same crew ⇒ same id). */
+export function crewGoalId(name: string): string {
+  const slug =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 48) || 'crew';
+  return `crew-${slug}`;
+}
+
+/** In-process default runner: marks a task completed. Replaced by real execution in production. */
+async function defaultTaskRunner(task: Task): Promise<TaskRunResult> {
+  return { taskId: task.id, status: 'completed', output: `completed: ${task.title}`, durationMs: 0 };
+}
+
+function parseMetric(text: string, key: string): number | undefined {
+  const m = new RegExp(`${key}=(\\d+)`).exec(text);
+  return m ? Number.parseInt(m[1], 10) : undefined;
+}
+
+/**
+ * A separate evaluator for crew completion. It grades purely from the evidence
+ * the worker surfaces (`tasks_completed`/`tasks_total`/`tasks_failed` plus the
+ * validation exit code) and never re-runs the work. Its id differs from the
+ * worker's, so the loop's separation invariant holds.
+ */
+export function crewCompletionEvaluator(id = 'crew-evaluator'): Evaluator {
+  return functionEvaluator(id, (_contract, result) => {
+    const surfaced = `${result.summary}\n${result.result ?? ''}`;
+    const total = parseMetric(surfaced, 'tasks_total') ?? 0;
+    const completed = parseMetric(surfaced, 'tasks_completed') ?? 0;
+    const failed = parseMetric(surfaced, 'tasks_failed') ?? 0;
+    const cleanExit = typeof result.command === 'string' && result.exitCode === 0;
+    const conditionMet = total > 0 && completed === total && failed === 0 && cleanExit;
+    const progress = total > 0 ? completed / total : 0;
+    const reason = conditionMet
+      ? `all ${total} task(s) completed, 0 failed, clean validation run`
+      : `${completed}/${total} task(s) completed, ${failed} failed${cleanExit ? '' : ', validation not clean'}`;
+    const evidence: Evidence = { reason };
+    if (result.command !== undefined) evidence.command = result.command;
+    if (result.result !== undefined) evidence.result = result.result;
+    return { conditionMet, progress, evidence };
+  });
+}
+
+function buildCrewRetrospective(record: GoalRecord, store: GoalStore, now: () => string): string {
+  const checkpoints = store.readCheckpoints(record.id);
+  const shipped = checkpoints.filter(c => c.validation.passed).map(c => `- ${c.title}`);
+  return [
+    `# Retrospective: ${record.contract.objective}`,
+    '',
+    `**Outcome:** ${record.state}`,
+    `**Checkpoints:** ${checkpoints.length}`,
+    `**Generated:** ${now()}`,
+    '',
+    '## What shipped',
+    shipped.length ? shipped.join('\n') : '- (no passing checkpoints recorded)',
+    '',
+    '## Stopping condition',
+    `- ${record.contract.stoppingCondition}`,
+    `- Verified: ${record.achievedCondition ? 'yes' : 'no'}`,
+    '',
+  ].join('\n');
 }

--- a/src/crew/events.ts
+++ b/src/crew/events.ts
@@ -9,7 +9,13 @@ type EventType =
   | 'task:failed'
   | 'agent:spawned'
   | 'agent:died'
-  | 'agent:retried';
+  | 'agent:retried'
+  | 'goal:started'
+  | 'goal:checkpoint'
+  | 'goal:paused'
+  | 'goal:resumed'
+  | 'goal:completed'
+  | 'goal:cleared';
 
 interface CrewEvent {
   type: EventType;

--- a/src/crew/index.ts
+++ b/src/crew/index.ts
@@ -1,9 +1,11 @@
-export { Crew } from './crew';
-export type { CrewConfig, CrewOutput, TaskOutput } from './crew';
+export { Crew, crewGoalId, crewCompletionEvaluator } from './crew';
+export type { CrewConfig, CrewOutput, TaskOutput, TaskRunResult, TaskRunner, KickoffOptions } from './crew';
 export { Agent } from './agent';
 export type { AgentConfig } from './agent';
 export { Task } from './task';
 export type { TaskConfig, TaskStatus } from './task';
 export { computeWaves } from './process';
+export { createCheckpoint, checkpointToString, toGoalCheckpointDraft } from './checkpoint';
+export type { Checkpoint, GoalCheckpointBridge } from './checkpoint';
 export { eventBus } from './events';
 export type { EventType, CrewEvent } from './events';

--- a/src/goal/contract.ts
+++ b/src/goal/contract.ts
@@ -1,0 +1,223 @@
+/**
+ * Goal contract — the durable, verifiable agreement that drives an autonomous
+ * goal loop.
+ *
+ * A goal is a 7-field contract. Every field is required before a goal can
+ * activate; missing any one means the runner refuses to start. The stopping
+ * condition must be transcript/state-verifiable so a *separate* evaluator can
+ * judge completion from surfaced evidence alone — it never re-runs the work.
+ */
+
+export type GoalState = 'draft' | 'active' | 'paused' | 'completed' | 'cleared';
+
+/** Clear aliases accepted by the lifecycle (mirrors the /goal contract). */
+export const CLEAR_ALIASES = ['clear', 'stop', 'off', 'reset', 'none', 'cancel'] as const;
+export type ClearAlias = typeof CLEAR_ALIASES[number];
+
+export function isClearAlias(word: string): word is ClearAlias {
+  return (CLEAR_ALIASES as readonly string[]).includes(word.trim().toLowerCase());
+}
+
+/** Optional but strongly recommended context describing where/how the loop runs. */
+export interface ExecutionContext {
+  cwd?: string;
+  shell?: string;
+  timeoutSeconds?: number;
+  requiredServices?: string[];
+  networkPolicy?: string;
+  sideEffectBoundaries?: string;
+}
+
+/** The 7-field goal contract (+ optional execution context). */
+export interface GoalContract {
+  /** One sentence: what the agent is trying to achieve. */
+  objective: string;
+  /** Exactly when to stop. Must be runnable or observable (transcript-verifiable). */
+  stoppingCondition: string;
+  /** Command(s) that prove progress at every checkpoint. */
+  validationLoop: string;
+  /** Files, docs, issues, logs to read before acting. */
+  inputsToReadFirst: string[];
+  /** Hard rules that must hold throughout. */
+  constraints: string[];
+  /** Specific actions the agent must not take. */
+  forbiddenMoves: string[];
+  /** How often to write a progress entry and what proves a checkpoint complete. */
+  checkpointCadence: string;
+  /** Optional execution context (cwd, shell, timeout, services, side-effects). */
+  executionContext?: ExecutionContext;
+}
+
+export const REQUIRED_CONTRACT_FIELDS = [
+  'objective',
+  'stoppingCondition',
+  'validationLoop',
+  'inputsToReadFirst',
+  'constraints',
+  'forbiddenMoves',
+  'checkpointCadence',
+] as const;
+
+export type RequiredContractField = typeof REQUIRED_CONTRACT_FIELDS[number];
+
+const ARRAY_FIELDS: readonly RequiredContractField[] = [
+  'inputsToReadFirst',
+  'constraints',
+  'forbiddenMoves',
+];
+
+export interface ContractValidation {
+  valid: boolean;
+  missing: RequiredContractField[];
+  errors: string[];
+}
+
+/**
+ * Signals that make a stopping condition transcript-verifiable: a runnable
+ * command, a measurable threshold, or an observable artifact.
+ */
+const VERIFICATION_SIGNALS: readonly RegExp[] = [
+  /`[^`]+`/, // inline command or artifact in backticks
+  /\bexit(?:s|ed|ing)?\b[^.]*\b\d+\b/i, // "exits 0", "exit code 0"
+  /\bexit code\b/i,
+  /\bpass(?:es|ing|ed)?\b/i,
+  /\bgreen\b/i,
+  /\b0\s+(?:matches|errors|failures|warnings)\b/i,
+  /\bno\s+(?:matches|errors|failures|warnings)\b/i,
+  /\breturns?\b/i,
+  /\breports?\b/i,
+  /\bsucceeds?\b/i,
+  /[<>]=?\s*\d/, // threshold e.g. ">= 80"
+  /\b\d+(?:\.\d+)?\s*%/, // percentage threshold
+  /\b[\w./-]+\.(?:ts|js|tsx|jsx|py|go|json|md|txt|out|xml|yml|yaml|toml|lock|html|csv|cfg|ini)\b/i, // artifact file
+  /\b(?:test|tests|suite|build|lint|typecheck|coverage|compiles?)\b/i,
+];
+
+/** Pure "vibe" conditions the evaluator could never judge — rejected outright. */
+const VIBE_ONLY = /^(?:make it (?:better|nicer|good|work)|looks? good|done|finish(?:ed)?|improve(?: it)?|good enough|works?|ship it|clean it up|polish(?: it)?|be careful)\.?$/i;
+
+/**
+ * A stopping condition is verifiable when it references something an evaluator
+ * can judge from surfaced evidence: a command, a measurable threshold, or an
+ * observable artifact — and it is not a bare "vibe" phrase.
+ */
+export function isStoppingConditionVerifiable(condition: string): boolean {
+  const c = (condition ?? '').trim();
+  if (c.length < 8) return false;
+  if (VIBE_ONLY.test(c)) return false;
+  return VERIFICATION_SIGNALS.some(rx => rx.test(c));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** Validate contract completeness + stopping-condition verifiability. */
+export function validateContract(partial: Partial<GoalContract> | null | undefined): ContractValidation {
+  const c = (partial ?? {}) as Record<string, unknown>;
+  const missing: RequiredContractField[] = [];
+  const errors: string[] = [];
+
+  for (const field of REQUIRED_CONTRACT_FIELDS) {
+    const value = c[field];
+    if (ARRAY_FIELDS.includes(field)) {
+      if (!Array.isArray(value) || value.length === 0 || !value.some(isNonEmptyString)) {
+        missing.push(field);
+      }
+    } else if (!isNonEmptyString(value)) {
+      missing.push(field);
+    }
+  }
+
+  if (isNonEmptyString(c.stoppingCondition) && !isStoppingConditionVerifiable(c.stoppingCondition as string)) {
+    errors.push(
+      'stoppingCondition is not transcript-verifiable: reference a runnable command, ' +
+        'a measurable threshold, or an observable artifact',
+    );
+  }
+
+  return { valid: missing.length === 0 && errors.length === 0, missing, errors };
+}
+
+/** Trim strings and drop empty array entries, producing a validated contract. */
+export function normalizeContract(partial: Partial<GoalContract>): GoalContract {
+  const validation = validateContract(partial);
+  if (!validation.valid) {
+    const problems = [
+      validation.missing.length ? `missing: ${validation.missing.join(', ')}` : '',
+      ...validation.errors,
+    ].filter(Boolean);
+    throw new Error(`Invalid goal contract — ${problems.join('; ')}`);
+  }
+
+  const cleanArray = (values: string[] | undefined): string[] =>
+    (values ?? []).map(v => v.trim()).filter(v => v.length > 0);
+
+  const contract: GoalContract = {
+    objective: partial.objective!.trim(),
+    stoppingCondition: partial.stoppingCondition!.trim(),
+    validationLoop: partial.validationLoop!.trim(),
+    inputsToReadFirst: cleanArray(partial.inputsToReadFirst),
+    constraints: cleanArray(partial.constraints),
+    forbiddenMoves: cleanArray(partial.forbiddenMoves),
+    checkpointCadence: partial.checkpointCadence!.trim(),
+  };
+  if (partial.executionContext) {
+    contract.executionContext = partial.executionContext;
+  }
+  return contract;
+}
+
+export interface ContractMarkdownMeta {
+  id?: string;
+  state?: GoalState;
+  branch?: string;
+  startedAt?: string;
+  lastCheckpointAt?: string;
+  autopilot?: boolean;
+}
+
+function bullets(items: string[]): string {
+  return items.length ? items.map(i => `  - ${i}`).join('\n') : '  - (none)';
+}
+
+/** Render a human-readable, git-trackable goal contract (mirrors the template). */
+export function contractToMarkdown(contract: GoalContract, meta: ContractMarkdownMeta = {}): string {
+  const ctx = contract.executionContext;
+  const lines: string[] = [
+    `# Goal: ${contract.objective}`,
+    '',
+    `**State:** ${meta.state ?? 'draft'}`,
+  ];
+  if (meta.id) lines.push(`**Id:** ${meta.id}`);
+  if (meta.branch) lines.push(`**Branch:** ${meta.branch}`);
+  if (meta.startedAt) lines.push(`**Started:** ${meta.startedAt}`);
+  if (meta.lastCheckpointAt) lines.push(`**Last checkpoint:** ${meta.lastCheckpointAt}`);
+  if (meta.autopilot !== undefined) lines.push(`**Autopilot:** ${meta.autopilot ? 'yes' : 'no'}`);
+  lines.push(
+    '',
+    '## Contract',
+    '',
+    `- **Objective:** ${contract.objective}`,
+    `- **Stopping condition:** ${contract.stoppingCondition}`,
+    `- **Validation loop:** \`${contract.validationLoop}\``,
+    '- **Inputs to read first:**',
+    bullets(contract.inputsToReadFirst),
+    '- **Constraints:**',
+    bullets(contract.constraints),
+    '- **Forbidden moves:**',
+    bullets(contract.forbiddenMoves),
+    `- **Checkpoint cadence:** ${contract.checkpointCadence}`,
+  );
+  if (ctx) {
+    lines.push('- **Execution context:**');
+    if (ctx.cwd) lines.push(`  - cwd: \`${ctx.cwd}\``);
+    if (ctx.shell) lines.push(`  - shell: \`${ctx.shell}\``);
+    if (ctx.timeoutSeconds !== undefined) lines.push(`  - timeout per validation run: \`${ctx.timeoutSeconds}s\``);
+    if (ctx.requiredServices?.length) lines.push(`  - required services: ${ctx.requiredServices.join(', ')}`);
+    if (ctx.networkPolicy) lines.push(`  - network/secrets policy: ${ctx.networkPolicy}`);
+    if (ctx.sideEffectBoundaries) lines.push(`  - side-effect boundaries: ${ctx.sideEffectBoundaries}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}

--- a/src/goal/evaluator.ts
+++ b/src/goal/evaluator.ts
@@ -1,0 +1,230 @@
+/**
+ * Evaluator abstraction for the goal loop.
+ *
+ * The worker performs one slice of work per turn and *surfaces* evidence
+ * (a summary plus, optionally, the validation command it ran and that
+ * command's result/exit code). A **separate** evaluator then grades progress
+ * from that surfaced evidence alone — the worker never grades itself. The
+ * interface is the pluggable seam: a2a-crews' model/provider layer can supply
+ * any grader via {@link functionEvaluator} or a custom {@link Evaluator}.
+ */
+
+import type { GoalContract } from './contract';
+
+/** Auditable evidence attached to every evaluation (reason/command/result). */
+export interface Evidence {
+  reason: string;
+  command?: string;
+  result?: string;
+}
+
+/**
+ * Result surfaced by the worker for a single turn/slice. The evaluator may only
+ * read what the worker surfaces here; it does not re-run the work.
+ */
+export interface WorkerResult {
+  /** Identity of the worker that produced this result. Must differ from the evaluator. */
+  workerId: string;
+  turn: number;
+  /** Compact description of the slice the worker completed this turn. */
+  summary: string;
+  /** Validation command the worker ran (if any). */
+  command?: string;
+  /** Surfaced output of the validation command (truncated transcript). */
+  result?: string;
+  /** Exit code of the validation command (0 = success). */
+  exitCode?: number;
+  /** Tokens spent this turn (for budget tracking). */
+  tokens?: number;
+  /** True when this slice targets the same failing area as the previous turn. */
+  sameSlice?: boolean;
+}
+
+export interface Evaluation {
+  conditionMet: boolean;
+  /** 0..1 fraction of the stopping condition's checks satisfied by surfaced evidence. */
+  progress: number;
+  evidence: Evidence;
+  /** Identity of the evaluator (proves separation from the worker). */
+  evaluatorId: string;
+}
+
+export interface WorkerTurnContext {
+  contract: GoalContract;
+  turn: number;
+  plan: readonly string[];
+  lastEvaluation?: Evaluation;
+}
+
+/** A worker performs one slice of work per turn. Distinct from the evaluator. */
+export interface Worker {
+  readonly id: string;
+  runTurn(context: WorkerTurnContext): WorkerResult | Promise<WorkerResult>;
+}
+
+/** A separate grader. The worker never grades itself; a distinct evaluator does. */
+export interface Evaluator {
+  readonly id: string;
+  evaluate(
+    contract: GoalContract,
+    result: WorkerResult,
+    history: readonly Evaluation[],
+  ): Evaluation | Promise<Evaluation>;
+}
+
+/** Thrown when the evaluator is not separate from the worker. */
+export class EvaluatorSeparationError extends Error {
+  constructor(id: string) {
+    super(`evaluator must be separate from the worker (both had id "${id}"); the worker cannot grade itself`);
+    this.name = 'EvaluatorSeparationError';
+  }
+}
+
+/**
+ * Assert the evaluator is distinct from the worker. Enforces the core rule that
+ * post-turn evaluation uses a separate grader, not the worker model.
+ */
+export function assertSeparateEvaluator(worker: { id: string }, evaluator: { id: string }): void {
+  if (worker.id === evaluator.id) {
+    throw new EvaluatorSeparationError(worker.id);
+  }
+}
+
+type ThresholdOp = '>=' | '<=' | '>' | '<' | '==';
+interface Threshold {
+  op: ThresholdOp;
+  value: number;
+}
+
+const THRESHOLD_RE = /(>=|<=|==|>|<|=)\s*(\d+(?:\.\d+)?)/g;
+const NUMBER_RE = /\d+(?:\.\d+)?/g;
+const POSITIVE_SIGNAL =
+  /\b(?:pass(?:es|ed|ing)?|green|success(?:ful)?|succeeded|0\s+(?:matches|errors|failures)|no\s+(?:matches|errors|failures)|all tests? (?:pass|passed|green)|ok)\b/i;
+
+function parseThresholds(condition: string): Threshold[] {
+  const out: Threshold[] = [];
+  let m: RegExpExecArray | null;
+  THRESHOLD_RE.lastIndex = 0;
+  while ((m = THRESHOLD_RE.exec(condition)) !== null) {
+    const op = (m[1] === '=' ? '==' : m[1]) as ThresholdOp;
+    out.push({ op, value: parseFloat(m[2]) });
+  }
+  return out;
+}
+
+function numbersIn(text: string): number[] {
+  return (text.match(NUMBER_RE) ?? []).map(parseFloat);
+}
+
+function thresholdSatisfied(t: Threshold, nums: readonly number[]): boolean {
+  return nums.some(n => {
+    switch (t.op) {
+      case '>=':
+        return n >= t.value;
+      case '<=':
+        return n <= t.value;
+      case '>':
+        return n > t.value;
+      case '<':
+        return n < t.value;
+      case '==':
+        return n === t.value;
+      default:
+        return false;
+    }
+  });
+}
+
+function truncate(text: string | undefined, max: number): string | undefined {
+  if (text === undefined) return undefined;
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+export interface DefaultEvaluatorOptions {
+  id?: string;
+}
+
+/**
+ * Conservative default grader. It declares the goal met only when the worker
+ * surfaces a *clean validation run* (a command with exit code 0) AND every
+ * numeric threshold in the stopping condition is satisfied by a number in the
+ * surfaced output AND the surfaced output shows a positive signal
+ * (pass/green/0 errors/success). It never trusts a worker's self-assessment;
+ * it reads only surfaced command/result evidence. Richer graders can be
+ * plugged via {@link functionEvaluator} or a custom {@link Evaluator}.
+ */
+export class DefaultEvaluator implements Evaluator {
+  readonly id: string;
+
+  constructor(options: DefaultEvaluatorOptions = {}) {
+    this.id = options.id ?? 'default-evaluator';
+  }
+
+  evaluate(contract: GoalContract, result: WorkerResult): Evaluation {
+    const surfaced = `${result.summary}\n${result.result ?? ''}`;
+    const thresholds = parseThresholds(contract.stoppingCondition);
+    const nums = numbersIn(surfaced);
+
+    const commandSurfaced = typeof result.command === 'string' && result.command.trim().length > 0;
+    const cleanExit = commandSurfaced && result.exitCode === 0;
+    const positive = POSITIVE_SIGNAL.test(surfaced);
+
+    // Individual checks that contribute to progress.
+    const checks: boolean[] = [cleanExit, positive, ...thresholds.map(t => thresholdSatisfied(t, nums))];
+    const passed = checks.filter(Boolean).length;
+    const progress = checks.length === 0 ? 0 : passed / checks.length;
+
+    const thresholdsOk = thresholds.every(t => thresholdSatisfied(t, nums));
+    const conditionMet = cleanExit && positive && thresholdsOk;
+
+    const reason = conditionMet
+      ? `stopping condition satisfied: clean validation (exit 0), positive signal, ${thresholds.length} threshold(s) met`
+      : [
+          cleanExit ? 'validation clean' : commandSurfaced ? `validation exit ${result.exitCode}` : 'no validation surfaced',
+          positive ? 'positive signal' : 'no positive signal',
+          thresholds.length ? `${thresholds.filter(t => thresholdSatisfied(t, nums)).length}/${thresholds.length} thresholds` : 'no thresholds',
+        ].join('; ');
+
+    const evidence: Evidence = { reason };
+    if (result.command !== undefined) evidence.command = result.command;
+    const trimmedResult = truncate(result.result, 600);
+    if (trimmedResult !== undefined) evidence.result = trimmedResult;
+
+    return { conditionMet, progress, evaluatorId: this.id, evidence };
+  }
+}
+
+/**
+ * Wrap a plain grading function as an {@link Evaluator}. Lets a model/provider
+ * hook supply the grader while the runner enforces separation from the worker.
+ */
+export function functionEvaluator(
+  id: string,
+  fn: (
+    contract: GoalContract,
+    result: WorkerResult,
+    history: readonly Evaluation[],
+  ) => Omit<Evaluation, 'evaluatorId'> | Promise<Omit<Evaluation, 'evaluatorId'>>,
+): Evaluator {
+  return {
+    id,
+    async evaluate(contract, result, history) {
+      const partial = await fn(contract, result, history);
+      return { ...partial, evaluatorId: id };
+    },
+  };
+}
+
+/** Wrap a plain function as a {@link Worker}. */
+export function functionWorker(
+  id: string,
+  fn: (context: WorkerTurnContext) => Omit<WorkerResult, 'workerId'> | Promise<Omit<WorkerResult, 'workerId'>>,
+): Worker {
+  return {
+    id,
+    async runTurn(context) {
+      const partial = await fn(context);
+      return { ...partial, workerId: id };
+    },
+  };
+}

--- a/src/goal/index.ts
+++ b/src/goal/index.ts
@@ -1,0 +1,94 @@
+/**
+ * Goal loop — durable, evaluator-graded autonomous work for a2a-crews.
+ *
+ * A goal is a 7-field contract with a transcript-verifiable stopping condition.
+ * The {@link GoalRunner} drives a {@link Worker} toward that condition, grading
+ * each turn with a *separate* {@link Evaluator}, checkpointing per cadence, and
+ * persisting durable state under `audits/goals/<id>/`.
+ *
+ * @example
+ * ```ts
+ * import { GoalRunner, DefaultEvaluator, functionWorker } from './goal';
+ *
+ * const runner = new GoalRunner();
+ * runner.start({
+ *   objective: 'Migrate the router to the new API',
+ *   stoppingCondition: '`bun test` exits 0 and coverage >= 80%',
+ *   validationLoop: 'bun test',
+ *   inputsToReadFirst: ['src/router.ts'],
+ *   constraints: ['No route shape changes'],
+ *   forbiddenMoves: ['Do not open a PR'],
+ *   checkpointCadence: 'every file migrated + tests green',
+ * });
+ *
+ * const worker = functionWorker('crew', () => ({
+ *   turn: 1, summary: 'migrated router', command: 'bun test', result: 'coverage 82%', exitCode: 0,
+ * }));
+ * await runner.run(worker, new DefaultEvaluator());
+ * ```
+ */
+
+export {
+  CLEAR_ALIASES,
+  contractToMarkdown,
+  isClearAlias,
+  isStoppingConditionVerifiable,
+  normalizeContract,
+  REQUIRED_CONTRACT_FIELDS,
+  validateContract,
+} from './contract';
+export type {
+  ClearAlias,
+  ContractMarkdownMeta,
+  ContractValidation,
+  ExecutionContext,
+  GoalContract,
+  GoalState,
+  RequiredContractField,
+} from './contract';
+
+export {
+  assertSeparateEvaluator,
+  DefaultEvaluator,
+  EvaluatorSeparationError,
+  functionEvaluator,
+  functionWorker,
+} from './evaluator';
+export type {
+  DefaultEvaluatorOptions,
+  Evaluation,
+  Evaluator,
+  Evidence,
+  Worker,
+  WorkerResult,
+  WorkerTurnContext,
+} from './evaluator';
+
+export {
+  checkpointKey,
+  defaultStage,
+  GoalStore,
+} from './store';
+export type {
+  GoalCheckpoint,
+  GoalCheckpointDraft,
+  GoalCheckpointValidation,
+  GoalRecord,
+  GoalStoreOptions,
+  StageFn,
+} from './store';
+
+export {
+  crewWorker,
+  GoalRunner,
+  nextAttempt,
+} from './runner';
+export type {
+  CheckpointCadencePolicy,
+  CrewStepContext,
+  GoalRunnerOptions,
+  GoalStatus,
+  RunResult,
+  TurnResult,
+  WorkingState,
+} from './runner';

--- a/src/goal/runner.ts
+++ b/src/goal/runner.ts
@@ -1,0 +1,601 @@
+/**
+ * Goal-loop runner — the working tier of the two-tier memory model and the
+ * engine that drives a crew/worker to a verifiable stopping condition.
+ *
+ * On each turn the runner (a) runs the worker, (b) invokes a *separate*
+ * evaluator that grades progress from surfaced evidence, (c) writes a
+ * checkpoint per the cadence, and (d) stops when the stopping condition is met.
+ * It auto-pauses after two consecutive validation failures on the same slice so
+ * it never compounds bad work.
+ *
+ * There is exactly one active goal per session; starting a new one replaces the
+ * prior goal and resets the turn/token counters. Lifecycle operations mirror the
+ * `/goal` slash commands: start/setObjective, pause, resume, clear (writes a
+ * retrospective), status, checkpoint, show.
+ */
+
+import type { GoalContract, GoalState } from './contract';
+import {
+  CLEAR_ALIASES,
+  contractToMarkdown,
+  isClearAlias,
+  normalizeContract,
+} from './contract';
+import {
+  assertSeparateEvaluator,
+  EvaluatorSeparationError,
+  type Evaluation,
+  type Evaluator,
+  type Worker,
+  type WorkerResult,
+  type WorkerTurnContext,
+} from './evaluator';
+import {
+  checkpointKey,
+  GoalStore,
+  type GoalCheckpoint,
+  type GoalCheckpointDraft,
+  type GoalRecord,
+} from './store';
+import { eventBus, type EventType } from '../crew/events';
+import type { Crew } from '../crew/crew';
+
+export { CLEAR_ALIASES, isClearAlias };
+
+/** Increment a verification attempt counter that defaults to 0 (first attempt → 1). */
+export function nextAttempt(current = 0): number {
+  return current + 1;
+}
+
+/** In-memory (working-tier) state for the single active goal. */
+export interface WorkingState {
+  goalId: string;
+  state: GoalState;
+  turns: number;
+  tokenSpend: number;
+  consecutiveFailures: number;
+  /** Verification attempts. Starts at 0; incremented once per turn. */
+  attempts: number;
+  checkpointCount: number;
+  plan: string[];
+  startedAt: string;
+  lastReason: string;
+  lastCheckpoint?: GoalCheckpoint;
+  lastEvaluation?: Evaluation;
+  achievedCondition?: string | null;
+}
+
+/** Compact, auditable status snapshot (used by `status`/`show`). */
+export interface GoalStatus {
+  goalId: string | null;
+  state: GoalState | 'idle';
+  objective: string | null;
+  activeCondition: string | null;
+  achievedCondition: string | null;
+  turns: number;
+  tokenSpend: number;
+  checkpoints: number;
+  consecutiveFailures: number;
+  attempts: number;
+  runtimeMs: number;
+  lastReason: string;
+  branch: string | null;
+}
+
+export interface TurnResult {
+  result: WorkerResult;
+  evaluation: Evaluation;
+  checkpoint?: GoalCheckpoint;
+  status: GoalStatus;
+}
+
+export interface RunResult {
+  status: GoalStatus;
+  checkpoints: GoalCheckpoint[];
+  turnsRun: number;
+}
+
+export type CheckpointCadencePolicy =
+  | 'every-turn'
+  | ((ctx: { turn: number; validationPassed: boolean; evaluation: Evaluation }) => boolean);
+
+export interface GoalRunnerOptions {
+  store?: GoalStore;
+  autopilot?: boolean;
+  now?: () => string;
+  idFactory?: (objective: string) => string;
+  cadence?: CheckpointCadencePolicy;
+  /** Auto-pause after this many consecutive failures on the same slice. Default 2. */
+  maxConsecutiveFailures?: number;
+  /** Emit lifecycle events to the crew event bus. Default true. */
+  emitEvents?: boolean;
+  /** Optional lifecycle hook (in addition to the event bus). */
+  onEvent?: (type: EventType, data: Record<string, unknown>) => void;
+}
+
+function defaultIdFactory(objective: string): string {
+  const slug =
+    objective
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40)
+      .replace(/-+$/, '') || 'goal';
+  const suffix = crypto.randomUUID().slice(0, 8);
+  return `${slug}-${suffix}`;
+}
+
+export class GoalRunner {
+  private readonly store: GoalStore;
+  private readonly autopilot: boolean;
+  private readonly now: () => string;
+  private readonly idFactory: (objective: string) => string;
+  private readonly cadence: CheckpointCadencePolicy;
+  private readonly maxConsecutiveFailures: number;
+  private readonly emitEvents: boolean;
+  private readonly onEvent?: (type: EventType, data: Record<string, unknown>) => void;
+
+  private record: GoalRecord | null = null;
+  private working: WorkingState | null = null;
+  private evaluations: Evaluation[] = [];
+
+  constructor(options: GoalRunnerOptions = {}) {
+    this.store = options.store ?? new GoalStore();
+    this.autopilot = options.autopilot ?? true;
+    this.now = options.now ?? this.store.now;
+    this.idFactory = options.idFactory ?? defaultIdFactory;
+    this.cadence = options.cadence ?? 'every-turn';
+    this.maxConsecutiveFailures = options.maxConsecutiveFailures ?? 2;
+    this.emitEvents = options.emitEvents ?? true;
+    this.onEvent = options.onEvent;
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────
+
+  /**
+   * Start (or replace) the goal. Validates the 7-field contract, clears any
+   * prior active goal (one active goal per session), persists the durable
+   * contract, and resets the working counters.
+   */
+  start(input: Partial<GoalContract>, opts: { branch?: string; autopilot?: boolean } = {}): GoalRecord {
+    const contract = normalizeContract(input); // throws on incomplete/unverifiable
+
+    const priorActive = this.store.findActive();
+    if (priorActive) this.clearRecord(priorActive, 'replaced by a new goal');
+    if (this.record && this.working && this.working.state === 'active' && this.record.id !== priorActive?.id) {
+      this.clearRecord(this.record, 'replaced by a new goal');
+    }
+
+    const id = this.idFactory(contract.objective);
+    const ts = this.now();
+    const record: GoalRecord = {
+      id,
+      contract,
+      state: 'active',
+      branch: opts.branch,
+      autopilot: opts.autopilot ?? this.autopilot,
+      createdAt: ts,
+      updatedAt: ts,
+      achievedCondition: null,
+    };
+    this.record = record;
+    this.working = {
+      goalId: id,
+      state: 'active',
+      turns: 0,
+      tokenSpend: 0,
+      consecutiveFailures: 0,
+      attempts: 0,
+      checkpointCount: 0,
+      plan: [],
+      startedAt: ts,
+      lastReason: 'goal set',
+      achievedCondition: null,
+    };
+    this.evaluations = [];
+    this.store.writeRecord(record);
+    this.emit('goal:started', { goalId: id, objective: contract.objective });
+    return record;
+  }
+
+  /** Alias for {@link start}. */
+  setObjective(input: Partial<GoalContract>, opts: { branch?: string; autopilot?: boolean } = {}): GoalRecord {
+    return this.start(input, opts);
+  }
+
+  pause(): GoalStatus {
+    const { working, record } = this.requireActive('pause');
+    working.state = 'paused';
+    record.state = 'paused';
+    working.lastReason = 'paused';
+    this.persist();
+    this.emit('goal:paused', { goalId: working.goalId });
+    return this.status();
+  }
+
+  /** Re-prime from the durable contract + last checkpoint, then continue. */
+  resume(): GoalStatus {
+    if (!this.working || !this.record) throw new Error('resume: no goal loaded');
+    if (this.working.state !== 'paused') {
+      throw new Error(`resume: requires paused state, got '${this.working.state}'`);
+    }
+    const fresh = this.store.readRecord(this.record.id);
+    if (fresh) this.record = fresh;
+    const checkpoints = this.store.readCheckpoints(this.record.id);
+    this.working.lastCheckpoint = checkpoints[checkpoints.length - 1];
+    this.working.checkpointCount = checkpoints.length;
+    this.working.state = 'active';
+    this.record.state = 'active';
+    this.working.consecutiveFailures = 0;
+    this.working.lastReason = 'resumed';
+    this.persist();
+    this.emit('goal:resumed', { goalId: this.working.goalId });
+    return this.status();
+  }
+
+  /** Clear the goal (aliases: stop/off/reset/none/cancel). Writes a retrospective; keeps history. */
+  clear(reason: string = 'clear'): GoalStatus {
+    if (!this.working || !this.record) throw new Error('clear: no goal loaded');
+    const normalized = isClearAlias(reason) ? reason.trim().toLowerCase() : reason;
+    this.clearRecord(this.record, normalized);
+    this.working.state = 'cleared';
+    this.working.achievedCondition = this.record.achievedCondition ?? this.working.achievedCondition ?? null;
+    this.working.lastReason = `goal ${normalized}`;
+    this.emit('goal:cleared', { goalId: this.working.goalId, reason: normalized });
+    return this.status();
+  }
+
+  status(): GoalStatus {
+    if (!this.working || !this.record) {
+      return {
+        goalId: null,
+        state: 'idle',
+        objective: null,
+        activeCondition: null,
+        achievedCondition: null,
+        turns: 0,
+        tokenSpend: 0,
+        checkpoints: 0,
+        consecutiveFailures: 0,
+        attempts: 0,
+        runtimeMs: 0,
+        lastReason: '',
+        branch: null,
+      };
+    }
+    const w = this.working;
+    const r = this.record;
+    const runtimeMs = Date.parse(this.now()) - Date.parse(w.startedAt);
+    return {
+      goalId: w.goalId,
+      state: w.state,
+      objective: r.contract.objective,
+      activeCondition: w.state === 'active' ? r.contract.stoppingCondition : null,
+      achievedCondition: w.achievedCondition ?? r.achievedCondition ?? null,
+      turns: w.turns,
+      tokenSpend: w.tokenSpend,
+      checkpoints: w.checkpointCount,
+      consecutiveFailures: w.consecutiveFailures,
+      attempts: w.attempts,
+      runtimeMs: Number.isFinite(runtimeMs) ? Math.max(0, runtimeMs) : 0,
+      lastReason: w.lastReason,
+      branch: r.branch ?? null,
+    };
+  }
+
+  /** Full contract (equivalent to `/goal show`). */
+  show(): { record: GoalRecord; contract: GoalContract; markdown: string } | null {
+    if (!this.record) return null;
+    return {
+      record: this.record,
+      contract: this.record.contract,
+      markdown: contractToMarkdown(this.record.contract, {
+        id: this.record.id,
+        state: this.record.state,
+        branch: this.record.branch,
+        startedAt: this.record.createdAt,
+        lastCheckpointAt: this.record.updatedAt,
+        autopilot: this.record.autopilot,
+      }),
+    };
+  }
+
+  /** Force-write a checkpoint now (equivalent to `/goal checkpoint`). Idempotent. */
+  checkpoint(input: { title?: string; verified?: string; remains?: string; passed?: boolean } = {}): GoalCheckpoint {
+    const { working, record } = this.requireLoaded('checkpoint');
+    const title = input.title ?? `manual checkpoint at turn ${working.turns}`;
+    const verified = input.verified ?? '';
+    const reason = `manual checkpoint: ${verified || 'progress recorded'}`;
+    const draft: GoalCheckpointDraft = {
+      goalId: working.goalId,
+      turn: working.turns,
+      timestamp: this.now(),
+      title,
+      verified,
+      remains: input.remains ?? '',
+      blocked: null,
+      validation: { passed: input.passed ?? true, attempt: working.attempts },
+      evidence: { reason },
+      evaluatorId: 'manual',
+      progress: working.lastEvaluation?.progress ?? 0,
+      key: checkpointKey({ goalId: working.goalId, turn: working.turns, title, verified, reason }),
+    };
+    const { checkpoint, appended } = this.store.appendCheckpoint(draft);
+    working.checkpointCount = this.store.readCheckpoints(working.goalId).length;
+    working.lastCheckpoint = checkpoint;
+    if (appended) {
+      record.updatedAt = checkpoint.timestamp;
+      this.store.writeRecord(record);
+      this.emit('goal:checkpoint', { goalId: working.goalId, checkpointNumber: checkpoint.checkpointNumber, manual: true });
+    }
+    return checkpoint;
+  }
+
+  // ── Run loop ─────────────────────────────────────────────────────────
+
+  /** Run one turn: worker → separate evaluator → checkpoint → stop-check. */
+  async runTurn(worker: Worker, evaluator: Evaluator): Promise<TurnResult> {
+    const { working, record } = this.requireActive('runTurn');
+    assertSeparateEvaluator(worker, evaluator);
+
+    const context: WorkerTurnContext = {
+      contract: record.contract,
+      turn: working.turns + 1,
+      plan: working.plan,
+      lastEvaluation: working.lastEvaluation,
+    };
+    const result = await worker.runTurn(context);
+    if (result.workerId === evaluator.id) throw new EvaluatorSeparationError(evaluator.id);
+
+    working.turns += 1;
+    working.tokenSpend += result.tokens ?? 0;
+    working.attempts = nextAttempt(working.attempts);
+
+    const commandSurfaced = typeof result.command === 'string' && result.command.trim().length > 0;
+    const validationRan = commandSurfaced && result.exitCode !== undefined;
+    const validationPassed = validationRan ? result.exitCode === 0 : true;
+    const validationFailed = validationRan && result.exitCode !== 0;
+
+    if (validationFailed) {
+      working.consecutiveFailures = result.sameSlice === false ? 1 : working.consecutiveFailures + 1;
+    } else {
+      working.consecutiveFailures = 0;
+    }
+
+    const evaluation = await evaluator.evaluate(record.contract, result, this.evaluations);
+    this.evaluations.push(evaluation);
+    working.lastEvaluation = evaluation;
+    working.lastReason = evaluation.evidence.reason;
+
+    const autoPause = working.consecutiveFailures >= this.maxConsecutiveFailures;
+    const cadenceFires = this.shouldCheckpoint({ turn: working.turns, validationPassed, evaluation });
+
+    let checkpoint: GoalCheckpoint | undefined;
+    if (evaluation.conditionMet || cadenceFires || autoPause) {
+      checkpoint = this.writeCheckpoint({
+        working,
+        record,
+        result,
+        evaluation,
+        validationPassed,
+        autoPause,
+        title: evaluation.conditionMet ? `turn ${working.turns}: stopping condition met` : undefined,
+      });
+    }
+
+    if (evaluation.conditionMet) {
+      working.state = 'completed';
+      record.state = 'completed';
+      working.achievedCondition = record.contract.stoppingCondition;
+      record.achievedCondition = record.contract.stoppingCondition;
+      record.updatedAt = this.now();
+      this.store.writeRecord(record);
+      this.store.writeRetrospective(record.id, this.buildRetrospective(record, 'completed'));
+      this.store.stage(record.id);
+      this.emit('goal:completed', { goalId: working.goalId, condition: record.contract.stoppingCondition });
+    } else if (autoPause) {
+      working.state = 'paused';
+      record.state = 'paused';
+      working.lastReason = `auto-paused after ${working.consecutiveFailures} consecutive validation failures`;
+      this.persist();
+      this.emit('goal:paused', { goalId: working.goalId, auto: true });
+    } else {
+      this.persist();
+    }
+
+    return { result, evaluation, checkpoint, status: this.status() };
+  }
+
+  /** Run turns until the goal completes, auto-pauses, or the turn cap is hit. */
+  async run(worker: Worker, evaluator: Evaluator, opts: { maxTurns?: number } = {}): Promise<RunResult> {
+    assertSeparateEvaluator(worker, evaluator);
+    const maxTurns = opts.maxTurns ?? 50;
+    let turnsRun = 0;
+    while (this.working && this.working.state === 'active' && turnsRun < maxTurns) {
+      await this.runTurn(worker, evaluator);
+      turnsRun += 1;
+    }
+    return {
+      status: this.status(),
+      checkpoints: this.working ? this.store.readCheckpoints(this.working.goalId) : [],
+      turnsRun,
+    };
+  }
+
+  // ── Durable ↔ working rehydration ────────────────────────────────────
+
+  /** Load the single active goal from durable storage into working memory. */
+  loadActive(): GoalRecord | null {
+    const active = this.store.findActive();
+    return active ? this.load(active.id) : null;
+  }
+
+  /** Hydrate working state from a durable record + its checkpoint log. */
+  load(id: string): GoalRecord | null {
+    const record = this.store.readRecord(id);
+    if (!record) return null;
+    const checkpoints = this.store.readCheckpoints(id);
+    const last = checkpoints[checkpoints.length - 1];
+    this.record = record;
+    this.working = {
+      goalId: id,
+      state: record.state,
+      turns: last?.turn ?? 0,
+      tokenSpend: 0, // working-tier only; not persisted durably
+      consecutiveFailures: 0,
+      attempts: last?.validation.attempt ?? 0,
+      checkpointCount: checkpoints.length,
+      plan: [],
+      startedAt: record.createdAt,
+      lastReason: last?.evidence.reason ?? record.state,
+      lastCheckpoint: last,
+      achievedCondition: record.achievedCondition ?? null,
+    };
+    this.evaluations = [];
+    return record;
+  }
+
+  getStore(): GoalStore {
+    return this.store;
+  }
+
+  // ── Internals ────────────────────────────────────────────────────────
+
+  private shouldCheckpoint(ctx: { turn: number; validationPassed: boolean; evaluation: Evaluation }): boolean {
+    return this.cadence === 'every-turn' ? true : this.cadence(ctx);
+  }
+
+  private writeCheckpoint(args: {
+    working: WorkingState;
+    record: GoalRecord;
+    result: WorkerResult;
+    evaluation: Evaluation;
+    validationPassed: boolean;
+    autoPause: boolean;
+    title?: string;
+  }): GoalCheckpoint {
+    const { working, record, result, evaluation, validationPassed, autoPause } = args;
+    const title = (args.title ?? `turn ${working.turns}: ${result.summary}`).slice(0, 140);
+    const verified = validationPassed ? result.summary || 'slice complete' : 'validation failing';
+    const remains = evaluation.conditionMet ? 'none' : 'stopping condition not yet met';
+    const blocked = autoPause ? `auto-paused after ${working.consecutiveFailures} consecutive failures` : null;
+    const draft: GoalCheckpointDraft = {
+      goalId: working.goalId,
+      turn: working.turns,
+      timestamp: this.now(),
+      title,
+      verified,
+      remains,
+      blocked,
+      validation: {
+        command: result.command,
+        result: result.result,
+        passed: validationPassed,
+        attempt: working.attempts,
+      },
+      evidence: evaluation.evidence,
+      evaluatorId: evaluation.evaluatorId,
+      progress: evaluation.progress,
+      key: checkpointKey({
+        goalId: working.goalId,
+        turn: working.turns,
+        title,
+        verified,
+        validationResult: result.result,
+        reason: evaluation.evidence.reason,
+      }),
+    };
+    const { checkpoint, appended } = this.store.appendCheckpoint(draft);
+    working.checkpointCount = this.store.readCheckpoints(working.goalId).length;
+    working.lastCheckpoint = checkpoint;
+    if (appended) {
+      record.updatedAt = checkpoint.timestamp;
+      this.store.writeRecord(record);
+      this.emit('goal:checkpoint', { goalId: working.goalId, checkpointNumber: checkpoint.checkpointNumber });
+    }
+    return checkpoint;
+  }
+
+  private buildRetrospective(record: GoalRecord, reason: string): string {
+    const checkpoints = this.store.readCheckpoints(record.id);
+    const shipped = checkpoints.filter(c => c.validation.passed).map(c => `- ${c.title}`);
+    return [
+      `# Retrospective: ${record.contract.objective}`,
+      '',
+      `**Outcome:** ${reason}`,
+      `**State:** ${record.state}`,
+      `**Checkpoints:** ${checkpoints.length}`,
+      `**Generated:** ${this.now()}`,
+      '',
+      '## What shipped',
+      shipped.length ? shipped.join('\n') : '- (no passing checkpoints recorded)',
+      '',
+      '## Stopping condition',
+      `- ${record.contract.stoppingCondition}`,
+      `- Verified: ${record.achievedCondition ? 'yes' : 'no'}`,
+      '',
+      '## Constraints held',
+      record.contract.constraints.length ? record.contract.constraints.map(c => `- ${c}`).join('\n') : '- (none)',
+      '',
+    ].join('\n');
+  }
+
+  private clearRecord(record: GoalRecord, reason: string): void {
+    record.state = 'cleared';
+    record.updatedAt = this.now();
+    this.store.writeRecord(record);
+    this.store.writeRetrospective(record.id, this.buildRetrospective(record, reason));
+    this.store.stage(record.id);
+  }
+
+  private persist(): void {
+    if (!this.record || !this.working) return;
+    this.record.updatedAt = this.now();
+    this.store.writeRecord(this.record);
+  }
+
+  private requireLoaded(action: string): { working: WorkingState; record: GoalRecord } {
+    if (!this.working || !this.record) throw new Error(`${action}: no goal loaded`);
+    return { working: this.working, record: this.record };
+  }
+
+  private requireActive(action: string): { working: WorkingState; record: GoalRecord } {
+    const { working, record } = this.requireLoaded(action);
+    if (working.state !== 'active') {
+      throw new Error(`${action}: requires an active goal, got '${working.state}'`);
+    }
+    return { working, record };
+  }
+
+  private emit(type: EventType, data: Record<string, unknown>): void {
+    if (this.emitEvents) eventBus.emit(type, data);
+    this.onEvent?.(type, data);
+  }
+}
+
+// ── Crew integration ───────────────────────────────────────────────────
+
+export interface CrewStepContext extends WorkerTurnContext {
+  crew: Crew;
+}
+
+/**
+ * Wrap a crew run as a {@link Worker}: each turn calls `step`, which runs the
+ * crew's next slice and surfaces the evidence the evaluator will grade. This is
+ * the seam that puts a crew run under a goal loop without the worker grading
+ * itself.
+ */
+export function crewWorker(
+  crew: Crew,
+  step: (context: CrewStepContext) => Omit<WorkerResult, 'workerId'> | Promise<Omit<WorkerResult, 'workerId'>>,
+  id?: string,
+): Worker {
+  const workerId = id ?? `crew:${crew.name}`;
+  return {
+    id: workerId,
+    async runTurn(context) {
+      const partial = await step({ ...context, crew });
+      return { ...partial, workerId };
+    },
+  };
+}

--- a/src/goal/store.ts
+++ b/src/goal/store.ts
@@ -1,0 +1,262 @@
+/**
+ * Durable, git-trackable persistence for goals — the second tier of the
+ * two-tier memory model.
+ *
+ * Working state (turn/token counters, in-memory plan, latest checkpoint) lives
+ * in the {@link GoalRunner}. Durable state lives on disk under
+ * `audits/goals/<id>/`:
+ *
+ *   - `contract.json`      the 7-field contract + record metadata (machine)
+ *   - `goal.md`            the same contract, human-readable (git-trackable)
+ *   - `checkpoints.jsonl`  append-only checkpoint log (one JSON object per line)
+ *   - `retrospective.md`   written on clear/complete
+ *
+ * Fixes carried over from the source design:
+ *   - Durability: every write also *stages* its files (`git add`) so durable
+ *     files are never left untracked after a checkpoint.
+ *   - Idempotency: checkpoints are keyed; re-appending the same key is a no-op,
+ *     and record/markdown writes overwrite rather than duplicate.
+ *   - Portability: timestamps come from the JS runtime (never `date -u`), and
+ *     staging shells out via argv (no shell string), so it works on Windows
+ *     (PowerShell) and Unix alike.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
+import type { GoalContract, GoalState } from './contract';
+import { contractToMarkdown } from './contract';
+import type { Evidence } from './evaluator';
+
+export interface GoalRecord {
+  id: string;
+  contract: GoalContract;
+  state: GoalState;
+  branch?: string;
+  autopilot: boolean;
+  createdAt: string;
+  updatedAt: string;
+  achievedCondition?: string | null;
+}
+
+export interface GoalCheckpointValidation {
+  command?: string;
+  result?: string;
+  passed: boolean;
+  /** Verification attempt count for this slice. Starts at 0; first attempt is 1. */
+  attempt: number;
+}
+
+export interface GoalCheckpoint {
+  goalId: string;
+  checkpointNumber: number;
+  turn: number;
+  timestamp: string;
+  title: string;
+  verified: string;
+  remains: string;
+  blocked: string | null;
+  validation: GoalCheckpointValidation;
+  evidence: Evidence;
+  evaluatorId: string;
+  progress: number;
+  commitSha?: string;
+  /** Idempotency key — appending the same key twice is a no-op. */
+  key: string;
+}
+
+/** A checkpoint before the store assigns its sequence number. */
+export type GoalCheckpointDraft = Omit<GoalCheckpoint, 'checkpointNumber'>;
+
+export type StageFn = (paths: string[], repoDir: string) => void;
+
+export interface GoalStoreOptions {
+  /** Root under which `audits/goals/<id>/` is written. Defaults to cwd. */
+  baseDir?: string;
+  /** Whether to `git add` durable files after each write. Defaults to true. */
+  autoStage?: boolean;
+  /** Override the staging implementation (injected in tests). */
+  stage?: StageFn;
+  /** Timestamp source. Defaults to the runtime ISO clock (never a shell). */
+  now?: () => string;
+}
+
+/** Best-effort cross-platform `git add` via argv (no shell). */
+export function defaultStage(paths: string[], repoDir: string): void {
+  if (paths.length === 0) return;
+  try {
+    spawnSync('git', ['add', '--', ...paths], { cwd: repoDir, stdio: 'ignore' });
+  } catch {
+    // Staging is best-effort: durability of the files themselves does not
+    // depend on the working tree being a git repo.
+  }
+}
+
+/** Compute a deterministic idempotency key for a checkpoint's content. */
+export function checkpointKey(parts: {
+  goalId: string;
+  turn: number;
+  title: string;
+  verified: string;
+  validationResult?: string;
+  reason: string;
+}): string {
+  const material = [
+    parts.goalId,
+    String(parts.turn),
+    parts.title,
+    parts.verified,
+    parts.validationResult ?? '',
+    parts.reason,
+  ].join('\u0000');
+  return createHash('sha256').update(material).digest('hex').slice(0, 16);
+}
+
+export class GoalStore {
+  readonly baseDir: string;
+  private readonly autoStage: boolean;
+  private readonly stageFn: StageFn;
+  readonly now: () => string;
+
+  constructor(options: GoalStoreOptions = {}) {
+    this.baseDir = resolve(options.baseDir ?? process.cwd());
+    this.autoStage = options.autoStage ?? true;
+    this.stageFn = options.stage ?? defaultStage;
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  goalsRoot(): string {
+    return join(this.baseDir, 'audits', 'goals');
+  }
+  goalDir(id: string): string {
+    return join(this.goalsRoot(), id);
+  }
+  contractJsonPath(id: string): string {
+    return join(this.goalDir(id), 'contract.json');
+  }
+  goalMdPath(id: string): string {
+    return join(this.goalDir(id), 'goal.md');
+  }
+  checkpointsPath(id: string): string {
+    return join(this.goalDir(id), 'checkpoints.jsonl');
+  }
+  retrospectivePath(id: string): string {
+    return join(this.goalDir(id), 'retrospective.md');
+  }
+
+  private ensureDir(id: string): void {
+    mkdirSync(this.goalDir(id), { recursive: true });
+  }
+
+  private maybeStage(paths: string[]): void {
+    if (this.autoStage) this.stageFn(paths, this.baseDir);
+  }
+
+  /** Persist the record (contract.json + goal.md). Overwrites — idempotent. */
+  writeRecord(record: GoalRecord): string[] {
+    this.ensureDir(record.id);
+    const jsonPath = this.contractJsonPath(record.id);
+    const mdPath = this.goalMdPath(record.id);
+    writeFileSync(jsonPath, `${JSON.stringify(record, null, 2)}\n`, 'utf-8');
+    writeFileSync(
+      mdPath,
+      contractToMarkdown(record.contract, {
+        id: record.id,
+        state: record.state,
+        branch: record.branch,
+        startedAt: record.createdAt,
+        lastCheckpointAt: record.updatedAt,
+        autopilot: record.autopilot,
+      }),
+      'utf-8',
+    );
+    const paths = [jsonPath, mdPath];
+    this.maybeStage(paths);
+    return paths;
+  }
+
+  readRecord(id: string): GoalRecord | null {
+    const path = this.contractJsonPath(id);
+    if (!existsSync(path)) return null;
+    try {
+      return JSON.parse(readFileSync(path, 'utf-8')) as GoalRecord;
+    } catch {
+      return null;
+    }
+  }
+
+  listRecords(): GoalRecord[] {
+    const root = this.goalsRoot();
+    if (!existsSync(root)) return [];
+    const records: GoalRecord[] = [];
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const record = this.readRecord(entry.name);
+      if (record) records.push(record);
+    }
+    records.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return records;
+  }
+
+  /** The single active goal, if any (most recent wins if the invariant broke). */
+  findActive(): GoalRecord | null {
+    const active = this.listRecords().filter(r => r.state === 'active');
+    if (active.length === 0) return null;
+    return active[active.length - 1];
+  }
+
+  readCheckpoints(id: string): GoalCheckpoint[] {
+    const path = this.checkpointsPath(id);
+    if (!existsSync(path)) return [];
+    const out: GoalCheckpoint[] = [];
+    for (const line of readFileSync(path, 'utf-8').split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        out.push(JSON.parse(trimmed) as GoalCheckpoint);
+      } catch {
+        // Skip malformed lines rather than corrupt the whole log.
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Append a checkpoint. Idempotent: if a checkpoint with the same key already
+   * exists, returns it unchanged (`appended: false`) without writing. Otherwise
+   * assigns the next checkpoint number, appends one JSONL line, and stages the
+   * durable files.
+   */
+  appendCheckpoint(draft: GoalCheckpointDraft): { appended: boolean; checkpoint: GoalCheckpoint } {
+    this.ensureDir(draft.goalId);
+    const existing = this.readCheckpoints(draft.goalId);
+    const dup = existing.find(cp => cp.key === draft.key);
+    if (dup) {
+      return { appended: false, checkpoint: dup };
+    }
+
+    const checkpoint: GoalCheckpoint = { ...draft, checkpointNumber: existing.length + 1 };
+    const path = this.checkpointsPath(draft.goalId);
+    // Re-read then rewrite the full log so numbering stays consistent even if
+    // the file was edited out-of-band; keeps the append atomic and idempotent.
+    const lines = [...existing, checkpoint].map(cp => JSON.stringify(cp));
+    writeFileSync(path, `${lines.join('\n')}\n`, 'utf-8');
+    this.maybeStage([path]);
+    return { appended: true, checkpoint };
+  }
+
+  /** Write (overwrite) the retrospective. Idempotent. */
+  writeRetrospective(id: string, markdown: string): string[] {
+    this.ensureDir(id);
+    const path = this.retrospectivePath(id);
+    writeFileSync(path, markdown.endsWith('\n') ? markdown : `${markdown}\n`, 'utf-8');
+    this.maybeStage([path]);
+    return path ? [path] : [];
+  }
+
+  /** Force staging of a goal's durable directory (best-effort). */
+  stage(id: string): void {
+    this.maybeStage([this.goalDir(id)]);
+  }
+}

--- a/tests/crew-goal-loop.test.ts
+++ b/tests/crew-goal-loop.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  Crew,
+  Task,
+  createCheckpoint,
+  crewCompletionEvaluator,
+  crewGoalId,
+  toGoalCheckpointDraft,
+  type TaskRunner,
+} from '../src/crew';
+import { EvaluatorSeparationError, GoalStore, type Evaluator } from '../src/goal';
+
+let base: string;
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'a2a-crew-loop-'));
+});
+afterEach(() => {
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function fixedNow(): () => string {
+  let n = 0;
+  return () => new Date(Date.UTC(2026, 0, 1, 0, 0, n++)).toISOString();
+}
+
+/** A store rooted at the isolated temp dir; staging disabled so no git side effects. */
+function store(): GoalStore {
+  return new GoalStore({ baseDir: base, autoStage: false, now: fixedNow() });
+}
+
+function featureCrew(): Crew {
+  return new Crew({
+    name: 'Feature Team',
+    scenario: 'ship feature X',
+    process: 'wave',
+    agents: [],
+    tasks: [
+      new Task({ id: 'design', title: 'Design', assignedTo: 'architect' }),
+      new Task({ id: 'build', title: 'Build', assignedTo: 'coder', dependsOn: ['design'] }),
+      new Task({ id: 'review', title: 'Review', assignedTo: 'reviewer', dependsOn: ['build'] }),
+    ],
+  });
+}
+
+// ── Checkpoint → goal-checkpoint bridge ────────────────────────────────
+
+describe('toGoalCheckpointDraft', () => {
+  test('maps a crew checkpoint into a durable, keyed draft', () => {
+    const cp = createCheckpoint({
+      role: 'coder',
+      checkpointNumber: 2,
+      currentTask: 'wave 2/3',
+      taskStatus: 'partial',
+      completedWork: ['build'],
+      remainingWork: ['review'],
+    });
+    const draft = toGoalCheckpointDraft(cp, {
+      goalId: 'crew-x',
+      turn: 2,
+      evaluatorId: 'crew-evaluator',
+      progress: 0.66,
+      passed: true,
+      attempt: 2,
+      evidence: { reason: '2/3 done' },
+      command: 'crews watch',
+      result: 'tasks_completed=2 tasks_total=3 tasks_failed=0',
+    });
+    expect(draft.goalId).toBe('crew-x');
+    expect(draft.turn).toBe(2);
+    expect(draft.verified).toBe('build');
+    expect(draft.remains).toBe('review');
+    expect(draft.evaluatorId).toBe('crew-evaluator');
+    expect(draft.validation.passed).toBe(true);
+    expect(draft.validation.attempt).toBe(2);
+    expect(draft.evidence.reason).toBe('2/3 done');
+    expect(draft.key).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test('key is stable for identical content and changes with content', () => {
+    const cp = createCheckpoint({ role: 'r', checkpointNumber: 1, currentTask: 'wave 1/1', completedWork: ['a'] });
+    const keyFor = (result: string): string =>
+      toGoalCheckpointDraft(cp, {
+        goalId: 'g',
+        turn: 1,
+        evaluatorId: 'e',
+        progress: 1,
+        passed: true,
+        attempt: 1,
+        evidence: { reason: 'done' },
+        command: 'c',
+        result,
+      }).key;
+    expect(keyFor('same')).toBe(keyFor('same'));
+    expect(keyFor('same')).not.toBe(keyFor('different'));
+  });
+});
+
+// ── Crew.kickoff durable loop ──────────────────────────────────────────
+
+describe('Crew.kickoff', () => {
+  test('completes when all tasks succeed and writes durable two-tier state', async () => {
+    const crew = featureCrew();
+    const s = store();
+    const out = await crew.kickoff({ store: s, now: fixedNow(), emitEvents: false });
+
+    // Working tier: returned in-memory result.
+    expect(out.tasks.length).toBe(3);
+    expect(out.tasks.every(t => t.status === 'completed')).toBe(true);
+    expect(out.waves).toBe(3);
+
+    // Durable tier: files under audits/goals/<id>/.
+    const id = crewGoalId('Feature Team');
+    expect(id).toBe('crew-feature-team');
+    expect(existsSync(s.contractJsonPath(id))).toBe(true);
+    expect(existsSync(s.goalMdPath(id))).toBe(true);
+    expect(existsSync(s.retrospectivePath(id))).toBe(true);
+
+    const rec = s.readRecord(id);
+    expect(rec).not.toBeNull();
+    expect(rec!.state).toBe('completed');
+    expect(rec!.achievedCondition).toBe(rec!.contract.stoppingCondition);
+
+    const cps = s.readCheckpoints(id);
+    expect(cps.length).toBe(3);
+    expect(cps[cps.length - 1].progress).toBe(1);
+    // Every checkpoint was graded by the separate evaluator, not the worker.
+    expect(cps.every(c => c.evaluatorId === 'crew-evaluator')).toBe(true);
+    expect(cps.every(c => c.evaluatorId !== 'crew:Feature Team')).toBe(true);
+  });
+
+  test('runs waves in dependency order through the worker', async () => {
+    const crew = featureCrew();
+    const seen: string[] = [];
+    const runTask: TaskRunner = (task, ctx) => {
+      seen.push(`${ctx.wave}:${task.id}`);
+      return { taskId: task.id, status: 'completed', durationMs: 1 };
+    };
+    const out = await crew.kickoff({ store: store(), runTask, emitEvents: false });
+    expect(seen).toEqual(['1:design', '2:build', '3:review']);
+    expect(out.waves).toBe(3);
+  });
+
+  test('rejects an evaluator whose id collides with the worker', async () => {
+    const crew = featureCrew();
+    const collide = crewCompletionEvaluator('crew:Feature Team');
+    await expect(crew.kickoff({ store: store(), evaluator: collide, emitEvents: false })).rejects.toThrow(
+      EvaluatorSeparationError,
+    );
+  });
+
+  test('throws if the evaluator impersonates the worker id at grade time', async () => {
+    const crew = featureCrew();
+    const liar: Evaluator = {
+      id: 'honest-id',
+      evaluate: () => ({ conditionMet: false, progress: 0, evaluatorId: 'crew:Feature Team', evidence: { reason: 'x' } }),
+    };
+    await expect(crew.kickoff({ store: store(), evaluator: liar, emitEvents: false })).rejects.toThrow(
+      EvaluatorSeparationError,
+    );
+  });
+
+  test('does not falsely complete when a task fails', async () => {
+    const crew = featureCrew();
+    const runTask: TaskRunner = task =>
+      task.id === 'build'
+        ? { taskId: task.id, status: 'failed', durationMs: 1 }
+        : { taskId: task.id, status: 'completed', durationMs: 1 };
+    const s = store();
+    const out = await crew.kickoff({ store: s, runTask, now: fixedNow(), emitEvents: false });
+
+    const id = crewGoalId('Feature Team');
+    const rec = s.readRecord(id);
+    expect(rec!.state).toBe('active'); // not 'completed'
+    expect(rec!.achievedCondition).toBeNull();
+    expect(out.tasks.find(t => t.taskId === 'build')!.status).toBe('failed');
+    expect(existsSync(s.retrospectivePath(id))).toBe(false); // retro only on completion
+  });
+
+  test('re-running the same crew appends no duplicate durable checkpoints', async () => {
+    const s = store();
+    await featureCrew().kickoff({ store: s, now: fixedNow(), emitEvents: false });
+    const id = crewGoalId('Feature Team');
+    const firstCount = s.readCheckpoints(id).length;
+    expect(firstCount).toBe(3);
+
+    await featureCrew().kickoff({ store: s, now: fixedNow(), emitEvents: false });
+    expect(s.readCheckpoints(id).length).toBe(firstCount);
+  });
+
+  test('stages durable files on every checkpoint', async () => {
+    const crew = featureCrew();
+    const staged: string[] = [];
+    const s = new GoalStore({ baseDir: base, stage: paths => staged.push(...paths), now: fixedNow() });
+    await crew.kickoff({ store: s, now: fixedNow(), emitEvents: false });
+
+    expect(staged.filter(p => p.endsWith('checkpoints.jsonl')).length).toBeGreaterThanOrEqual(3);
+    expect(staged.some(p => p.endsWith('contract.json'))).toBe(true);
+    expect(staged.some(p => p.endsWith('goal.md'))).toBe(true);
+  });
+});

--- a/tests/goal-contract.test.ts
+++ b/tests/goal-contract.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  contractToMarkdown,
+  isStoppingConditionVerifiable,
+  normalizeContract,
+  REQUIRED_CONTRACT_FIELDS,
+  validateContract,
+  type GoalContract,
+} from '../src/goal';
+
+function validContract(overrides: Partial<GoalContract> = {}): Partial<GoalContract> {
+  return {
+    objective: 'Migrate the router to the new API',
+    stoppingCondition: '`bun test` exits 0 and coverage >= 80%',
+    validationLoop: 'bun test',
+    inputsToReadFirst: ['src/router.ts'],
+    constraints: ['No route shape changes'],
+    forbiddenMoves: ['Do not open a PR'],
+    checkpointCadence: 'every file migrated + tests green',
+    ...overrides,
+  };
+}
+
+// ── Contract completeness ───────────────────────────────────────────
+
+describe('validateContract — completeness', () => {
+  test('accepts a complete 7-field contract', () => {
+    const result = validateContract(validContract());
+    expect(result.valid).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('ExecutionContext is optional', () => {
+    const withCtx = validContract({ executionContext: { cwd: '/repo', shell: 'pwsh' } });
+    expect(validateContract(withCtx).valid).toBe(true);
+    expect(validateContract(validContract()).valid).toBe(true);
+  });
+
+  test('flags every missing required field', () => {
+    for (const field of REQUIRED_CONTRACT_FIELDS) {
+      const partial = validContract();
+      delete (partial as Record<string, unknown>)[field];
+      const result = validateContract(partial);
+      expect(result.valid).toBe(false);
+      expect(result.missing).toContain(field);
+    }
+  });
+
+  test('treats empty strings and empty arrays as missing', () => {
+    const blankString = validateContract(validContract({ objective: '   ' }));
+    expect(blankString.missing).toContain('objective');
+
+    const emptyArray = validateContract(validContract({ constraints: [] }));
+    expect(emptyArray.missing).toContain('constraints');
+
+    const blankArrayEntries = validateContract(validContract({ forbiddenMoves: ['', '   '] }));
+    expect(blankArrayEntries.missing).toContain('forbiddenMoves');
+  });
+
+  test('null/undefined input reports all fields missing', () => {
+    expect(validateContract(null).missing.length).toBe(REQUIRED_CONTRACT_FIELDS.length);
+    expect(validateContract(undefined).valid).toBe(false);
+  });
+});
+
+// ── Stopping-condition verifiability ────────────────────────────────
+
+describe('isStoppingConditionVerifiable', () => {
+  test('accepts runnable / measurable / observable conditions', () => {
+    expect(isStoppingConditionVerifiable('`bun test` exits 0')).toBe(true);
+    expect(isStoppingConditionVerifiable('coverage >= 80%')).toBe(true);
+    expect(isStoppingConditionVerifiable('rg "gin\\." returns 0 matches')).toBe(true);
+    expect(isStoppingConditionVerifiable('the test suite passes')).toBe(true);
+    expect(isStoppingConditionVerifiable('produces a summary file at pr-summary.md')).toBe(true);
+  });
+
+  test('rejects vibe-only conditions', () => {
+    expect(isStoppingConditionVerifiable('make it better')).toBe(false);
+    expect(isStoppingConditionVerifiable('looks good')).toBe(false);
+    expect(isStoppingConditionVerifiable('done')).toBe(false);
+    expect(isStoppingConditionVerifiable('improve it')).toBe(false);
+  });
+
+  test('rejects empty or too-short conditions', () => {
+    expect(isStoppingConditionVerifiable('')).toBe(false);
+    expect(isStoppingConditionVerifiable('ok')).toBe(false);
+  });
+
+  test('validateContract surfaces an unverifiable stopping condition as an error', () => {
+    const result = validateContract(validContract({ stoppingCondition: 'make it nicer' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('transcript-verifiable'))).toBe(true);
+  });
+});
+
+// ── Normalization + markdown ────────────────────────────────────────
+
+describe('normalizeContract', () => {
+  test('trims strings and drops blank array entries', () => {
+    const contract = normalizeContract(
+      validContract({
+        objective: '  Migrate router  ',
+        inputsToReadFirst: ['src/router.ts', '', '  '],
+        constraints: ['  No route changes  '],
+      }),
+    );
+    expect(contract.objective).toBe('Migrate router');
+    expect(contract.inputsToReadFirst).toEqual(['src/router.ts']);
+    expect(contract.constraints).toEqual(['No route changes']);
+  });
+
+  test('throws on an invalid contract', () => {
+    expect(() => normalizeContract(validContract({ objective: '' }))).toThrow(/Invalid goal contract/);
+    expect(() => normalizeContract(validContract({ stoppingCondition: 'looks good' }))).toThrow(
+      /transcript-verifiable/,
+    );
+  });
+});
+
+describe('contractToMarkdown', () => {
+  test('renders every field with metadata', () => {
+    const md = contractToMarkdown(normalizeContract(validContract()), { id: 'g1', state: 'active', autopilot: true });
+    expect(md).toContain('# Goal: Migrate the router to the new API');
+    expect(md).toContain('**State:** active');
+    expect(md).toContain('**Stopping condition:**');
+    expect(md).toContain('**Validation loop:** `bun test`');
+    expect(md).toContain('**Forbidden moves:**');
+    expect(md).toContain('**Checkpoint cadence:**');
+  });
+});

--- a/tests/goal-runner.test.ts
+++ b/tests/goal-runner.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  assertSeparateEvaluator,
+  DefaultEvaluator,
+  EvaluatorSeparationError,
+  functionEvaluator,
+  functionWorker,
+  GoalRunner,
+  GoalStore,
+  nextAttempt,
+  type GoalContract,
+  type Worker,
+  type WorkerResult,
+} from '../src/goal';
+
+function contract(overrides: Partial<GoalContract> = {}): Partial<GoalContract> {
+  return {
+    objective: 'Raise coverage to 80%',
+    stoppingCondition: '`bun test` exits 0 and coverage >= 80%',
+    validationLoop: 'bun test',
+    inputsToReadFirst: ['tests/'],
+    constraints: ['Tests stay green'],
+    forbiddenMoves: ['No no-op tests'],
+    checkpointCadence: 'every test file + suite green',
+    ...overrides,
+  };
+}
+
+/** Emits one scripted result per turn (repeats the last step when exhausted). */
+function scriptedWorker(id: string, steps: Array<Omit<WorkerResult, 'workerId' | 'turn'>>): Worker {
+  let i = 0;
+  return functionWorker(id, ctx => {
+    const step = steps[Math.min(i, steps.length - 1)];
+    i += 1;
+    return { turn: ctx.turn, ...step };
+  });
+}
+
+let base: string;
+let runner: GoalRunner;
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'a2a-goal-runner-'));
+  runner = new GoalRunner({ store: new GoalStore({ baseDir: base, autoStage: false }), emitEvents: false });
+});
+afterEach(() => {
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ── Evaluator is separate from the worker ────────────────────────────
+
+describe('evaluator separation (worker does not self-grade)', () => {
+  test('assertSeparateEvaluator throws when ids match', () => {
+    expect(() => assertSeparateEvaluator({ id: 'same' }, { id: 'same' })).toThrow(EvaluatorSeparationError);
+    expect(() => assertSeparateEvaluator({ id: 'worker' }, { id: 'grader' })).not.toThrow();
+  });
+
+  test('runTurn refuses a worker and evaluator that share an id', async () => {
+    runner.start(contract());
+    const worker = functionWorker('shared', ctx => ({ turn: ctx.turn, summary: 'did work' }));
+    const evaluator = functionEvaluator('shared', () => ({ conditionMet: false, progress: 0, evidence: { reason: 'x' } }));
+    await expect(runner.runTurn(worker, evaluator)).rejects.toThrow(EvaluatorSeparationError);
+  });
+
+  test('the grade comes from the evaluator, not the worker result', async () => {
+    runner.start(contract());
+    const worker = functionWorker('worker', ctx => ({ turn: ctx.turn, summary: 'claims success', command: 'bun test', result: 'coverage 99%', exitCode: 0 }));
+    // A separate evaluator that always withholds completion, regardless of surfaced "success".
+    const strict = functionEvaluator('strict-grader', () => ({ conditionMet: false, progress: 0.5, evidence: { reason: 'not yet' } }));
+    const { evaluation } = await runner.runTurn(worker, strict);
+    expect(evaluation.evaluatorId).toBe('strict-grader');
+    expect(evaluation.conditionMet).toBe(false);
+    expect(runner.status().state).toBe('active');
+  });
+});
+
+// ── DefaultEvaluator grades only from surfaced evidence ──────────────
+
+describe('DefaultEvaluator', () => {
+  const evaluator = new DefaultEvaluator();
+
+  test('declares met on clean validation + positive signal + threshold satisfied', () => {
+    const result: WorkerResult = { workerId: 'w', turn: 1, summary: 'ran suite', command: 'bun test', result: 'all tests pass, coverage 82%', exitCode: 0 };
+    const evaluation = evaluator.evaluate(contract() as GoalContract, result, []);
+    expect(evaluation.conditionMet).toBe(true);
+    expect(evaluation.progress).toBe(1);
+  });
+
+  test('withholds completion when the threshold is unmet even if validation is clean', () => {
+    const result: WorkerResult = { workerId: 'w', turn: 1, summary: 'ran suite', command: 'bun test', result: 'all tests pass, coverage 61%', exitCode: 0 };
+    const evaluation = evaluator.evaluate(contract() as GoalContract, result, []);
+    expect(evaluation.conditionMet).toBe(false);
+  });
+
+  test('withholds completion when validation fails', () => {
+    const result: WorkerResult = { workerId: 'w', turn: 1, summary: 'ran suite', command: 'bun test', result: 'coverage 90% but 2 failing', exitCode: 1 };
+    const evaluation = evaluator.evaluate(contract() as GoalContract, result, []);
+    expect(evaluation.conditionMet).toBe(false);
+  });
+
+  test('records auditable evidence (reason/command/result)', () => {
+    const result: WorkerResult = { workerId: 'w', turn: 1, summary: 's', command: 'bun test', result: 'coverage 82% pass', exitCode: 0 };
+    const evaluation = evaluator.evaluate(contract() as GoalContract, result, []);
+    expect(evaluation.evidence.command).toBe('bun test');
+    expect(evaluation.evidence.reason.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Run loop: stop on met, auto-pause on repeated failure ────────────
+
+describe('run loop', () => {
+  test('stops when the stopping condition is met', async () => {
+    runner.start(contract());
+    const worker = scriptedWorker('worker', [
+      { summary: 'baseline', command: 'bun test', result: 'coverage 60% pass', exitCode: 0 },
+      { summary: 'added tests', command: 'bun test', result: 'coverage 85%, all tests pass', exitCode: 0 },
+    ]);
+    const out = await runner.run(worker, new DefaultEvaluator(), { maxTurns: 10 });
+    expect(out.status.state).toBe('completed');
+    expect(out.status.achievedCondition).toBe('`bun test` exits 0 and coverage >= 80%');
+    expect(out.turnsRun).toBe(2);
+  });
+
+  test('auto-pauses after two consecutive failures on the same slice', async () => {
+    runner.start(contract());
+    const worker = scriptedWorker('worker', [
+      { summary: 'attempt', command: 'bun test', result: 'boom', exitCode: 1, sameSlice: true },
+    ]);
+    const out = await runner.run(worker, new DefaultEvaluator(), { maxTurns: 10 });
+    expect(out.status.state).toBe('paused');
+    expect(out.status.consecutiveFailures).toBe(2);
+    expect(out.turnsRun).toBe(2);
+  });
+
+  test('a new slice resets the consecutive-failure counter', async () => {
+    runner.start(contract());
+    const worker = scriptedWorker('worker', [
+      { summary: 'fail A', command: 'bun test', result: 'x', exitCode: 1, sameSlice: true },
+      { summary: 'fail B (new slice)', command: 'bun test', result: 'x', exitCode: 1, sameSlice: false },
+    ]);
+    const first = await runner.runTurn(worker, new DefaultEvaluator());
+    expect(first.status.consecutiveFailures).toBe(1);
+    const second = await runner.runTurn(worker, new DefaultEvaluator());
+    expect(second.status.consecutiveFailures).toBe(1);
+    expect(second.status.state).toBe('active');
+  });
+
+  test('a checkpoint is written durably each turn', async () => {
+    const rec = runner.start(contract());
+    const worker = scriptedWorker('worker', [{ summary: 'slice', command: 'bun test', result: 'coverage 61% pass', exitCode: 0 }]);
+    await runner.runTurn(worker, new DefaultEvaluator());
+    await runner.runTurn(worker, new DefaultEvaluator());
+    const checkpoints = runner.getStore().readCheckpoints(rec.id);
+    expect(checkpoints.length).toBe(2);
+    expect(existsSync(runner.getStore().checkpointsPath(rec.id))).toBe(true);
+  });
+});
+
+// ── Attempt counter defaults to 0 (off-by-one fix) ───────────────────
+
+describe('verification attempt counter', () => {
+  test('nextAttempt defaults to 0 and first attempt is 1', () => {
+    expect(nextAttempt()).toBe(1);
+    expect(nextAttempt(0)).toBe(1);
+    expect(nextAttempt(1)).toBe(2);
+  });
+
+  test('a fresh goal starts at 0 attempts and reaches 1 after one turn (no double count)', async () => {
+    runner.start(contract());
+    expect(runner.status().attempts).toBe(0);
+    const worker = scriptedWorker('worker', [{ summary: 's', command: 'bun test', result: 'coverage 61% pass', exitCode: 0 }]);
+    const { checkpoint } = await runner.runTurn(worker, new DefaultEvaluator());
+    expect(runner.status().attempts).toBe(1);
+    expect(checkpoint?.validation.attempt).toBe(1);
+  });
+});
+
+// ── One active goal per session; replacement resets counters ─────────
+
+describe('single active goal', () => {
+  test('starting a new goal replaces the prior and resets counters', async () => {
+    const first = runner.start(contract({ objective: 'Goal A' }));
+    const worker = scriptedWorker('worker', [{ summary: 's', command: 'bun test', result: 'coverage 61% pass', exitCode: 0, tokens: 500 }]);
+    await runner.runTurn(worker, new DefaultEvaluator());
+    expect(runner.status().turns).toBe(1);
+    expect(runner.status().tokenSpend).toBe(500);
+
+    runner.start(contract({ objective: 'Goal B' }));
+    const status = runner.status();
+    expect(status.objective).toBe('Goal B');
+    expect(status.turns).toBe(0);
+    expect(status.tokenSpend).toBe(0);
+    expect(status.attempts).toBe(0);
+
+    // The prior goal is cleared in durable storage, not deleted.
+    expect(runner.getStore().readRecord(first.id)?.state).toBe('cleared');
+  });
+});
+
+// ── Lifecycle: pause / resume / clear + retrospective ────────────────
+
+describe('lifecycle', () => {
+  test('pause preserves state and resume re-primes to active', async () => {
+    runner.start(contract());
+    const worker = scriptedWorker('worker', [{ summary: 's', command: 'bun test', result: 'coverage 61% pass', exitCode: 0 }]);
+    await runner.runTurn(worker, new DefaultEvaluator());
+
+    expect(runner.pause().state).toBe('paused');
+    const resumed = runner.resume();
+    expect(resumed.state).toBe('active');
+    expect(resumed.turns).toBe(1); // counters preserved across pause/resume
+  });
+
+  test('clear writes a retrospective and keeps history', () => {
+    const rec = runner.start(contract());
+    const status = runner.clear();
+    expect(status.state).toBe('cleared');
+    expect(existsSync(runner.getStore().retrospectivePath(rec.id))).toBe(true);
+    expect(runner.getStore().readRecord(rec.id)?.state).toBe('cleared');
+  });
+
+  test('clear accepts aliases', () => {
+    for (const alias of ['stop', 'off', 'reset', 'none', 'cancel']) {
+      const local = new GoalRunner({ store: new GoalStore({ baseDir: base, autoStage: false }), emitEvents: false });
+      local.start(contract());
+      expect(local.clear(alias).state).toBe('cleared');
+    }
+  });
+});
+
+// ── Two-tier memory: durable → working rehydration ───────────────────
+
+describe('two-tier memory', () => {
+  test('loadActive rehydrates working state from durable storage', async () => {
+    const rec = runner.start(contract());
+    const worker = scriptedWorker('worker', [{ summary: 's', command: 'bun test', result: 'coverage 61% pass', exitCode: 0 }]);
+    await runner.runTurn(worker, new DefaultEvaluator());
+
+    // A fresh runner (new session) recovers the goal from disk.
+    const revived = new GoalRunner({ store: new GoalStore({ baseDir: base, autoStage: false }), emitEvents: false });
+    const loaded = revived.loadActive();
+    expect(loaded?.id).toBe(rec.id);
+    expect(revived.status().state).toBe('active');
+    expect(revived.status().checkpoints).toBe(1);
+  });
+});
+
+// ── Ported replay semantics (mirrors validate_goal_e2e.py) ───────────
+
+describe('lifecycle replay: set → fail → fail → pause → resume → pass → met', () => {
+  test('drives the full state machine to completion', async () => {
+    runner.start(contract());
+    const failing = scriptedWorker('worker', [{ summary: 'red', command: 'bun test', result: 'failing', exitCode: 1, sameSlice: true }]);
+    const evaluator = new DefaultEvaluator();
+
+    await runner.runTurn(failing, evaluator); // fail 1
+    expect(runner.status().state).toBe('active');
+    await runner.runTurn(failing, evaluator); // fail 2 → auto-pause
+    expect(runner.status().state).toBe('paused');
+
+    runner.resume();
+    expect(runner.status().state).toBe('active');
+
+    const passing = scriptedWorker('worker', [{ summary: 'green', command: 'bun test', result: 'all tests pass, coverage 88%', exitCode: 0 }]);
+    const final = await runner.runTurn(passing, evaluator);
+    expect(final.evaluation.conditionMet).toBe(true);
+    expect(runner.status().state).toBe('completed');
+    expect(runner.status().achievedCondition).toBeTruthy();
+  });
+});

--- a/tests/goal-store.test.ts
+++ b/tests/goal-store.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import {
+  checkpointKey,
+  GoalStore,
+  normalizeContract,
+  type GoalCheckpointDraft,
+  type GoalContract,
+  type GoalRecord,
+} from '../src/goal';
+
+function contract(): GoalContract {
+  return normalizeContract({
+    objective: 'Raise coverage',
+    stoppingCondition: '`bun test` exits 0 and coverage >= 80%',
+    validationLoop: 'bun test',
+    inputsToReadFirst: ['tests/'],
+    constraints: ['Tests stay green'],
+    forbiddenMoves: ['No no-op tests'],
+    checkpointCadence: 'every test file + suite green',
+  });
+}
+
+function record(id: string, state: GoalRecord['state'] = 'active'): GoalRecord {
+  const ts = '2026-01-01T00:00:00.000Z';
+  return { id, contract: contract(), state, autopilot: true, createdAt: ts, updatedAt: ts, achievedCondition: null };
+}
+
+function draft(goalId: string, overrides: Partial<GoalCheckpointDraft> = {}): GoalCheckpointDraft {
+  const base: GoalCheckpointDraft = {
+    goalId,
+    turn: 1,
+    timestamp: '2026-01-01T00:01:00.000Z',
+    title: 'turn 1: baseline',
+    verified: 'baseline measured',
+    remains: 'stopping condition not yet met',
+    blocked: null,
+    validation: { command: 'bun test', result: 'coverage 60%', passed: true, attempt: 1 },
+    evidence: { reason: 'progress 1/3' },
+    evaluatorId: 'default-evaluator',
+    progress: 0.33,
+    key: 'k-baseline',
+  };
+  return { ...base, ...overrides };
+}
+
+let base: string;
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'a2a-goal-store-'));
+});
+afterEach(() => {
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ── Durability ───────────────────────────────────────────────────────
+
+describe('GoalStore durability', () => {
+  test('writeRecord persists contract.json + goal.md and round-trips', () => {
+    const store = new GoalStore({ baseDir: base, autoStage: false });
+    const rec = record('coverage-1');
+    store.writeRecord(rec);
+
+    expect(existsSync(store.contractJsonPath('coverage-1'))).toBe(true);
+    expect(existsSync(store.goalMdPath('coverage-1'))).toBe(true);
+
+    const loaded = store.readRecord('coverage-1');
+    expect(loaded?.contract.objective).toBe('Raise coverage');
+    expect(readFileSync(store.goalMdPath('coverage-1'), 'utf-8')).toContain('# Goal: Raise coverage');
+  });
+
+  test('appendCheckpoint writes an append-only log', () => {
+    const store = new GoalStore({ baseDir: base, autoStage: false });
+    store.writeRecord(record('cov'));
+
+    const first = store.appendCheckpoint(draft('cov', { key: 'k1', title: 't1' }));
+    const second = store.appendCheckpoint(draft('cov', { key: 'k2', title: 't2', turn: 2 }));
+
+    expect(first.appended).toBe(true);
+    expect(first.checkpoint.checkpointNumber).toBe(1);
+    expect(second.checkpoint.checkpointNumber).toBe(2);
+
+    const all = store.readCheckpoints('cov');
+    expect(all.map(c => c.title)).toEqual(['t1', 't2']);
+    // durable file has exactly two JSONL lines
+    const lines = readFileSync(store.checkpointsPath('cov'), 'utf-8').trim().split('\n');
+    expect(lines.length).toBe(2);
+  });
+});
+
+// ── Idempotency ──────────────────────────────────────────────────────
+
+describe('GoalStore idempotency', () => {
+  test('re-appending the same key is a no-op', () => {
+    const store = new GoalStore({ baseDir: base, autoStage: false });
+    store.writeRecord(record('cov'));
+
+    const a = store.appendCheckpoint(draft('cov', { key: 'same' }));
+    const b = store.appendCheckpoint(draft('cov', { key: 'same' }));
+
+    expect(a.appended).toBe(true);
+    expect(b.appended).toBe(false);
+    expect(store.readCheckpoints('cov').length).toBe(1);
+  });
+
+  test('checkpointKey is deterministic for identical content', () => {
+    const parts = { goalId: 'g', turn: 3, title: 't', verified: 'v', validationResult: 'r', reason: 'why' };
+    expect(checkpointKey(parts)).toBe(checkpointKey({ ...parts }));
+    expect(checkpointKey(parts)).not.toBe(checkpointKey({ ...parts, turn: 4 }));
+  });
+
+  test('writeRecord overwrites rather than duplicating', () => {
+    const store = new GoalStore({ baseDir: base, autoStage: false });
+    store.writeRecord(record('cov'));
+    store.writeRecord(record('cov', 'paused'));
+    expect(store.readRecord('cov')?.state).toBe('paused');
+    expect(store.listRecords().length).toBe(1);
+  });
+});
+
+// ── Staging (durability fix) ─────────────────────────────────────────
+
+describe('GoalStore staging', () => {
+  test('invokes the stage hook with durable paths on every write', () => {
+    const staged: string[] = [];
+    const store = new GoalStore({ baseDir: base, stage: paths => staged.push(...paths) });
+    store.writeRecord(record('cov'));
+    store.appendCheckpoint(draft('cov'));
+
+    expect(staged.some(p => p.endsWith('contract.json'))).toBe(true);
+    expect(staged.some(p => p.endsWith('goal.md'))).toBe(true);
+    expect(staged.some(p => p.endsWith('checkpoints.jsonl'))).toBe(true);
+  });
+
+  test('durable files are git-staged in a real repo (source forgot to stage)', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'a2a-goal-git-'));
+    try {
+      execSync('git init', { cwd: repo, stdio: 'pipe' });
+      execSync('git config user.email "t@t.com"', { cwd: repo, stdio: 'pipe' });
+      execSync('git config user.name "T"', { cwd: repo, stdio: 'pipe' });
+
+      const store = new GoalStore({ baseDir: repo });
+      store.writeRecord(record('cov'));
+      store.appendCheckpoint(draft('cov'));
+
+      const stagedOutput = execSync('git diff --cached --name-only', { cwd: repo, encoding: 'utf-8' });
+      expect(stagedOutput).toContain('audits/goals/cov/contract.json');
+      expect(stagedOutput).toContain('audits/goals/cov/checkpoints.jsonl');
+      expect(stagedOutput).toContain('audits/goals/cov/goal.md');
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('timestamps come from the runtime clock, never a shell', () => {
+    const fixed = '2027-07-07T07:07:07.000Z';
+    const store = new GoalStore({ baseDir: base, autoStage: false, now: () => fixed });
+    expect(store.now()).toBe(fixed);
+    expect(new Date(store.now()).toISOString()).toBe(fixed);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **goal loop** to a2a-crews: wrap a crew run in a durable, verifiable contract and drive it to a transcript-verifiable stopping condition, grading each turn with a **separate** evaluator (the worker never grades itself).

A goal is a 7-field contract (`src/goal/contract.ts`): `objective`, `stoppingCondition`, `validationLoop`, `inputsToReadFirst`, `constraints`, `forbiddenMoves`, `checkpointCadence` (+ optional `executionContext`). A goal cannot activate unless the contract is complete and the stopping condition is transcript-verifiable.

## What's included

- **`GoalRunner`** (`src/goal/runner.ts`) — per-turn loop: run worker -> invoke a separate evaluator -> checkpoint per cadence -> stop when the condition is met. One active goal per session (a new goal replaces the prior and resets counters). Lifecycle ops mirror slash-command semantics: `start`/`setObjective`, `pause`, `resume`, `clear` (writes a retrospective), `status`, `checkpoint`, `show`. Auto-pauses after two consecutive validation failures on the same slice.
- **Evaluator abstraction** (`src/goal/evaluator.ts`) — pluggable `Evaluator` interface + `functionEvaluator` hook so the model/provider layer can supply the grader, plus a conservative `DefaultEvaluator` that grades **only from surfaced evidence** (clean validation exit + positive signal + numeric thresholds). `assertSeparateEvaluator` enforces that the evaluator is distinct from the worker.
- **Two-tier memory** — working state (in-memory plan + turn/token counters + latest checkpoint) vs **durable** state under `audits/goals/<id>/` (`contract.json`, human-readable `goal.md`, append-only `checkpoints.jsonl`, `retrospective.md`). Git-trackable and recoverable after a lost session (`loadActive`).
- **Crew integration** — `crewWorker()` adapter wraps a crew run as the loop worker; goal lifecycle events are emitted on the existing crew event bus (`src/crew/events.ts`).
- **CLI** — `crews goal start|status|show|list|checkpoint|pause|resume|clear` (`src/cli/index.ts`).
- **README** — new "Goal loop" section.

## Hardening

- **Checkpoint durability** — durable files are `git add`-staged on **every** write, so nothing is left untracked after a checkpoint.
- **Idempotency** — checkpoints are content-keyed; re-running the loop or a manual checkpoint never creates duplicate entries; record/markdown writes overwrite.
- **Portability (Windows + Unix)** — timestamps come from the JS runtime (never `date -u`); staging shells out via argv with no shell string.
- **Attempt counter** — the verification attempt counter defaults to `0` and increments once per turn (first attempt = 1), fixing the off-by-one double count.

## Tests & build

Added 39 unit tests (`tests/goal-*.test.ts`) covering contract completeness, stopping-condition verifiability, checkpoint durability + idempotency (incl. real-git staging), evaluator-separate-from-worker, the run loop, and a full lifecycle replay (set -> fail -> fail -> auto-pause -> resume -> pass -> met).

Commands run (Bun 1.3.14):
- `bun test` -> **222 pass, 0 fail** (183 pre-existing + 39 new)
- `bun run typecheck` (`tsc --noEmit`) -> **exit 0**
- `bun run build` (`bun build --compile`) -> **exit 0**



---

## Update — crew integration + dogfooding

Follow-up commits flesh out `Crew.kickoff()` as the **durable loop controller** and dogfood the goal loop while building it.

- **`Crew.kickoff()`** (`src/crew/crew.ts`) — schedules tasks into waves (`computeWaves`) and drives each wave as one checkpoint/evaluator cycle: run the wave's tasks (worker) -> grade with a **separate** `crewCompletionEvaluator` from surfaced evidence (`tasks_completed`/`tasks_total`/`tasks_failed` + exit code) -> write a durable, idempotent checkpoint under `audits/goals/<id>/` -> stop when all tasks complete. Task execution is injected via `runTask` (tests/dry-runs vs bridge-backed production); one active goal per session; stable `crewGoalId` makes re-runs idempotent.
- **`src/crew/checkpoint.ts`** — new `toGoalCheckpointDraft` bridges a crew `Checkpoint` into a content-keyed durable goal-checkpoint, keeping the evaluator's grade separate from the worker's verified/remaining work.
- **Dogfooding artifacts** (`audits/goals/goal-loop-feature/`) — the adopted 7-field goal contract plus an append-only checkpoint log with a **separate evaluator pass** (exact command + result) per unit of work, so the loop that built this feature is visible.
- **README** — documents `Crew.kickoff()` and the dogfooded artifacts.

**Tests:** +9 integration tests (`tests/crew-goal-loop.test.ts`) — bridge mapping + idempotent key; kickoff completion + durable two-tier state; wave order; evaluator separation at config **and** grade time; no false-completion on failure; idempotent re-run; staging on every checkpoint.

**Validation (Bun 1.3.14):** `bun test` -> **231 pass, 0 fail**; `bun x tsc --noEmit` -> **exit 0**.
